### PR TITLE
feat: restore public API with Sec-Fetch-Site browser guard and add AP…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@
 - **`laohuangli.go`** — 核心引擎：词条库加载、加权均衡随机抽取、模板渲染、每日缓存、今日指引生成
 - **`artificialIdiot.go`** — AI 内容生成：OpenAI API 调用、内容池管理（整点切换 + 预取）、prompt 构造；支持 `reloadAIConfig()` 热重载
 - **`config.go`** — 配置管理：从 scribble DB 读写配置，首次启动从环境变量初始化，支持运行时更新；Bot Token 和 Admin ID 变更后通过 `restartBot()` 热重载，无需手动重启。新增 `WebDomain` 字段用于 Webhook 域名配置
-- **`api.go`** — Fiber 路由注册：公开端点（`/api/cache`、`/api/templates`、`/api/entries`）、认证端点（`/api/auth/login`）、管理端点（`/api/admin/config`、`/api/admin/logs`）、Webhook 端点（`/webhook`）、SPA fallback（`/*`）。使用 Fiber 中间件做 JWT 认证
-- **`main.go`** — 应用入口：Fiber app 初始化、`go:embed` 嵌入前端静态文件、Telegram Bot 启动（Webhook 或 Long Polling 降级）
+- **`api.go`** — Fiber 路由注册：公开端点（`/api/today`、`/api/cache`、`/api/templates`、`/api/entries`，`BrowserOnlyMiddleware` Sec-Fetch-Site 校验 + 速率限制 5 次/分钟/IP 双重防护）、认证端点（`/api/auth/login`）、管理端点（`/api/admin/config`、`/api/admin/logs`、`/api/admin/tokens`）、用户统计端点（`/api/user/:id/stats`）、Webhook 端点（`/webhook`）、SPA fallback（`/*`）。使用 Fiber 中间件做 JWT 认证、API Token 认证、浏览器校验和速率限制
+- **`apiext.go`** — API Token 管理与用户统计：Token CRUD（生成/删除/列表/验证）、`APITokenMiddleware` 中间件、用户统计引擎（全量扫描 history + 增量更新）、统计缓存（内存 + scribble DB `datas/user_stats`）。`expireUserStatsDaily()` 在每日零点清理过期统计，`updateUserStatsOnFortune()` 在算命成功后增量更新
+- **`main.go`** — 应用入口：Fiber app 初始化、`go:embed` 嵌入前端静态文件、Telegram Bot 启动（Webhook 或 Long Polling 降级）、启动时加载 API Token 和用户统计缓存
 - **`logbuffer.go`** — 日志缓冲：内存环形缓冲区 + 文件持久化，支持通过 API 远程查看日志
 - **`nominate.go`** — 词条提名与投票系统：赞成/反对、快速通过/否决、相似度查重（Jaro 算法）
 - **`chats.go`** — Telegram 私聊状态机（IDLE → NOMINATE）、命令路由、管理员权限
@@ -64,7 +65,7 @@
 - **样式**：TailwindCSS + DaisyUI 组件库
 - **代码规范**：Prettier + ESLint（`npm run lint` / `npm run format`）
 - **数据获取**：通过 `+page.js` 客户端 load 函数调用 Go 后端 API（`/api/cache`、`/api/templates`、`/api/entries`），API 路径为相对路径（同源）
-- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向
+- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看、API Token 管理），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向
 - **SSR**：全局禁用（`+layout.js` 中 `export const ssr = false`）
 
 ### 部署与构建

--- a/README.md
+++ b/README.md
@@ -49,6 +49,123 @@ make clean
    - **提名助手**：查看模板词条信息，方便用户提名含有模板的词条
    - **管理后台**：通过 `http://your-domain:4090/admin` 访问（需登录），可查看实时日志、在线修改 Bot Token、管理员 ID、AI 配置等，无需重启服务
 
+## API 接口
+
+服务提供以下 RESTful API，所有路径相对于服务根地址（如 `http://localhost:4090`）。
+
+### 公开接口
+
+浏览器安全校验：所有公开接口通过 `Sec-Fetch-Site` 请求头校验仅允许浏览器访问（同源/同站请求），非浏览器请求返回 `403 Forbidden`。
+
+速率限制：每 IP 每分钟最多 5 次请求，超限返回 `429 Too Many Requests`。
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/api/today` | 获取今日已算命用户数量（返回 `{date, count}`） |
+| `GET` | `/api/cache` | 获取今日缓存（返回 `{date, today, caches}`，包含今日指引和众生列表） |
+| `GET` | `/api/templates` | 获取模板列表（返回模板 map） |
+| `GET` | `/api/entries` | 获取词条列表（返回 `{entries, entries_user}`） |
+
+`/api/cache` 响应示例：
+```json
+{
+  "date": "2026-05-27",
+  "today": {
+    "clothing": { "positive": "...", "negative": "..." },
+    "food": { "positive": "...", "negative": "..." },
+    "travel": { "positive": "...", "negative": "..." }
+  },
+  "caches": {
+    "123456": { "name": "AgentName", "result": "..." }
+  }
+}
+```
+
+### 认证接口
+
+| 方法 | 路径 | 认证方式 | 说明 |
+|------|------|----------|------|
+| `POST` | `/api/auth/login` | 无（请求体 `{username, password}`） | 管理员登录，返回 JWT token |
+
+### 管理接口（需 JWT 认证）
+
+请求头：`Authorization: Bearer <jwt_token>`
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/api/admin/config` | 获取配置（敏感字段脱敏） |
+| `PUT` | `/api/admin/config` | 更新配置（部分更新，仅传需修改的字段） |
+| `GET` | `/api/admin/logs` | 获取运行日志（可选参数 `?n=200` 指定条数） |
+| `GET` | `/api/admin/tokens` | 列出所有 API Token（token 脱敏显示） |
+| `POST` | `/api/admin/tokens` | 创建新 API Token（请求体 `{name}`） |
+| `DELETE` | `/api/admin/tokens/:id` | 删除指定 API Token |
+
+### 用户统计接口（需 API Token 认证）
+
+请求头：`Authorization: Bearer <api_token>`（通过管理后台「API Token」页面生成）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/api/user/:id/stats` | 获取用户算命统计（`:id` 为 Telegram 用户 ID） |
+
+响应示例：
+```json
+{
+  "user_id": "123456",
+  "total_count": 150,
+  "streak_count": 21,
+  "current_streak": 5,
+  "last_month_count": 25,
+  "last_fortune_date": "2026-05-27"
+}
+```
+
+### 接口测试
+
+```shell
+# 1. 获取今日已算命人数（公开接口，需浏览器 Sec-Fetch-Site 头，每分钟限 5 次）
+curl -H 'Sec-Fetch-Site: same-origin' http://localhost:4090/api/today
+
+# 2. 获取今日缓存（公开接口，需浏览器头）
+curl -H 'Sec-Fetch-Site: same-origin' http://localhost:4090/api/cache
+
+# 3. 获取模板列表（公开接口，需浏览器头）
+curl -H 'Sec-Fetch-Site: same-origin' http://localhost:4090/api/templates
+
+# 4. 获取词条列表（公开接口，需浏览器头）
+curl -H 'Sec-Fetch-Site: same-origin' http://localhost:4090/api/entries
+
+# 5. 无浏览器头请求 → 403 Forbidden
+curl http://localhost:4090/api/cache
+
+# 6. 管理员登录获取 JWT
+TOKEN=$(curl -s -X POST http://localhost:4090/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"laohuangli"}' | jq -r '.token')
+
+# 7. 查看配置
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4090/api/admin/config
+
+# 8. 创建 API Token
+API_TOKEN=$(curl -s -X POST http://localhost:4090/api/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"name":"测试 Token"}' | jq -r '.token')
+echo "API Token: $API_TOKEN"
+
+# 9. 列出所有 API Token
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4090/api/admin/tokens
+
+# 10. 使用 API Token 查询用户统计（替换 USER_ID 为实际 Telegram 用户 ID）
+curl -H "Authorization: Bearer $API_TOKEN" http://localhost:4090/api/user/123456/stats
+
+# 11. 删除 API Token（替换 TOKEN_ID 为实际 Token ID）
+curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:4090/api/admin/tokens/TOKEN_ID
+
+# 12. 测试速率限制（连续请求 6 次，第 6 次应返回 429）
+for i in $(seq 1 6); do curl -s -o /dev/null -w "请求 $i: HTTP %{http_code}\n" -H 'Sec-Fetch-Site: same-origin' http://localhost:4090/api/today; done
+```
+
 ## 数据
 
 词条与历史均使用[scribble](https://github.com/nanobox-io/golang-scribble)数据库保存。存放在项目根目录下。目录结构如下：
@@ -60,6 +177,8 @@ db/
 │   ├── laohuangli-user.json  #用户提名词条
 │   ├── laohuangli.json       #本地词条
 │   ├── templates.json        #词条模板
+│   ├── api_tokens.json       #API Token 存储
+│   ├── user_stats.json       #用户统计缓存
 │   └── bot.log               #运行日志
 └── history/
     └── $date.json            #历史记录

--- a/tgbot/api.go
+++ b/tgbot/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/limiter"
 	"github.com/gofiber/fiber/v3/middleware/static"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -145,39 +146,54 @@ func handleGetLogs(c fiber.Ctx) error {
 	return c.JSON(fiber.Map{"lines": lines})
 }
 
-// handleGetCache 获取今日缓存数据（公开 API）
-func handleGetCache(c fiber.Ctx) error {
-	c.Set("Access-Control-Allow-Origin", "*")
-	result := fiber.Map{
-		"date":   laoHL.cache.Date,
-		"today":  laoHL.cache.Today,
-		"caches": laoHL.cache.Caches,
+// BrowserOnlyMiddleware Sec-Fetch-Site 浏览器校验（Forbidden Header，JS 无法伪造）
+func BrowserOnlyMiddleware(c fiber.Ctx) error {
+	secFetchSite := c.Get("Sec-Fetch-Site")
+	if secFetchSite != "same-origin" && secFetchSite != "same-site" {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"error": "仅允许浏览器访问",
+		})
 	}
-	return c.JSON(result)
+	return c.Next()
 }
 
-// handleGetTemplates 获取模板列表（公开 API）
+// handleTodayCount 获取今日已算命用户数量（公开 API）
+func handleTodayCount(c fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"date":  laoHL.cache.Date,
+		"count": len(laoHL.cache.Caches),
+	})
+}
+
+// handleGetCache 获取今日缓存数据（今日指引 + 众生列表）
+func handleGetCache(c fiber.Ctx) error {
+	return c.JSON(laoHL.cache)
+}
+
+// handleGetTemplates 获取模板列表
 func handleGetTemplates(c fiber.Ctx) error {
-	c.Set("Access-Control-Allow-Origin", "*")
 	return c.JSON(laoHL.templates)
 }
 
-// handleGetEntries 获取词条列表（公开 API）
+// handleGetEntries 获取词条列表（本地 + 用户提名）
 func handleGetEntries(c fiber.Ctx) error {
-	c.Set("Access-Control-Allow-Origin", "*")
-	result := fiber.Map{
+	return c.JSON(fiber.Map{
 		"entries":      laoHL.entries,
 		"entries_user": laoHL.entriesUser,
-	}
-	return c.JSON(result)
+	})
 }
 
 // SetupRoutes 注册所有 Fiber 路由
 func SetupRoutes(app *fiber.App) {
-	// 公开 API
-	app.Get("/api/cache", handleGetCache)
-	app.Get("/api/templates", handleGetTemplates)
-	app.Get("/api/entries", handleGetEntries)
+	// 公开 API（速率限制：每 IP 每分钟最多 5 次）
+	publicLimiter := limiter.New(limiter.Config{
+		Max:        5,
+		Expiration: 1 * time.Minute,
+	})
+	app.Get("/api/today", BrowserOnlyMiddleware, publicLimiter, handleTodayCount)
+	app.Get("/api/cache", BrowserOnlyMiddleware, publicLimiter, handleGetCache)
+	app.Get("/api/templates", BrowserOnlyMiddleware, publicLimiter, handleGetTemplates)
+	app.Get("/api/entries", BrowserOnlyMiddleware, publicLimiter, handleGetEntries)
 
 	// 认证 API
 	app.Post("/api/auth/login", handleLogin)
@@ -186,6 +202,12 @@ func SetupRoutes(app *fiber.App) {
 	app.Get("/api/admin/config", AuthMiddleware, handleGetConfig)
 	app.Put("/api/admin/config", AuthMiddleware, handleUpdateConfig)
 	app.Get("/api/admin/logs", AuthMiddleware, handleGetLogs)
+	app.Get("/api/admin/tokens", AuthMiddleware, handleListTokens)
+	app.Post("/api/admin/tokens", AuthMiddleware, handleCreateToken)
+	app.Delete("/api/admin/tokens/:id", AuthMiddleware, handleDeleteToken)
+
+	// 用户统计 API（需要 API Token 认证）
+	app.Get("/api/user/:id/stats", APITokenMiddleware, handleUserStats)
 
 	// Webhook 端点（Telegram 推送），路径中附带 bot token 防止冲突
 	app.Post("/webhook/:token", handleWebhook)

--- a/tgbot/apiext.go
+++ b/tgbot/apiext.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	uuid "github.com/satori/go.uuid"
+)
+
+// APIToken API Token 数据结构
+type APIToken struct {
+	ID        string `json:"id"`
+	Token     string `json:"token"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+var (
+	apiTokens   map[string]APIToken
+	apiTokensMu sync.RWMutex
+)
+
+// UserStatsEntry 用户统计数据结构
+type UserStatsEntry struct {
+	TotalCount     int            `json:"total_count"`
+	StreakCount    int            `json:"streak_count"`
+	CurrentStreak  int            `json:"current_streak"`
+	LastMonthCount int            `json:"last_month_count"`
+	LastFortuneDate string        `json:"last_fortune_date"`
+	DailyCounts    map[string]int `json:"daily_counts"`
+	ComputedAt     string         `json:"computed_at"`
+}
+
+var (
+	userStatsCache map[int64]UserStatsEntry
+	userStatsMu    sync.RWMutex
+)
+
+// loadAPITokens 从 DB 加载 API Tokens 到内存
+func loadAPITokens() {
+	apiTokens = make(map[string]APIToken)
+	if err := db.Read("datas", "api_tokens", &apiTokens); err != nil {
+		fmt.Println("API Token 数据不存在或加载失败，初始化为空")
+		apiTokens = make(map[string]APIToken)
+	}
+	fmt.Printf("已加载 %d 个 API Token\n", len(apiTokens))
+}
+
+// saveAPITokens 持久化 API Tokens 到 DB
+func saveAPITokens() {
+	if err := db.Write("datas", "api_tokens", apiTokens); err != nil {
+		fmt.Println("保存 API Token 失败:", err)
+	}
+}
+
+// generateAPIToken 生成新 API Token
+func generateAPIToken(name string) APIToken {
+	raw := make([]byte, 32)
+	rand.Read(raw)
+	tokenStr := hex.EncodeToString(raw)
+
+	token := APIToken{
+		ID:        uuid.NewV4().String(),
+		Token:     tokenStr,
+		Name:      name,
+		CreatedAt: time.Now().Format(gTimeFormat),
+	}
+
+	apiTokensMu.Lock()
+	apiTokens[token.ID] = token
+	saveAPITokens()
+	apiTokensMu.Unlock()
+
+	return token
+}
+
+// deleteAPIToken 删除指定 API Token
+func deleteAPIToken(id string) bool {
+	apiTokensMu.Lock()
+	defer apiTokensMu.Unlock()
+	if _, ok := apiTokens[id]; !ok {
+		return false
+	}
+	delete(apiTokens, id)
+	saveAPITokens()
+	return true
+}
+
+// listAPITokens 返回所有 Token 列表（脱敏）
+func listAPITokens() []APIToken {
+	apiTokensMu.RLock()
+	defer apiTokensMu.RUnlock()
+	result := make([]APIToken, 0, len(apiTokens))
+	for _, t := range apiTokens {
+		display := t
+		if len(display.Token) > 16 {
+			display.Token = display.Token[:8] + "****" + display.Token[len(display.Token)-8:]
+		}
+		result = append(result, display)
+	}
+	return result
+}
+
+// validateAPIToken 验证 API Token 是否有效
+func validateAPIToken(tokenStr string) bool {
+	apiTokensMu.RLock()
+	defer apiTokensMu.RUnlock()
+	for _, t := range apiTokens {
+		if t.Token == tokenStr {
+			return true
+		}
+	}
+	return false
+}
+
+// APITokenMiddleware Fiber 中间件：验证 API Token
+func APITokenMiddleware(c fiber.Ctx) error {
+	authHeader := c.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "缺少 Authorization header"})
+	}
+	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+	if !validateAPIToken(tokenStr) {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "API Token 无效"})
+	}
+	return c.Next()
+}
+
+// --- Token 管理 Handlers ---
+
+// handleListTokens 列出所有 API Token（脱敏）
+func handleListTokens(c fiber.Ctx) error {
+	tokens := listAPITokens()
+	return c.JSON(fiber.Map{"tokens": tokens})
+}
+
+// handleCreateToken 创建新 API Token
+func handleCreateToken(c fiber.Ctx) error {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "请求格式错误"})
+	}
+	token := generateAPIToken(req.Name)
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"id":         token.ID,
+		"token":      token.Token,
+		"name":       token.Name,
+		"created_at": token.CreatedAt,
+	})
+}
+
+// handleDeleteToken 删除指定 API Token
+func handleDeleteToken(c fiber.Ctx) error {
+	id := c.Params("id")
+	if !deleteAPIToken(id) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Token 不存在"})
+	}
+	return c.JSON(fiber.Map{"status": "ok"})
+}
+
+// --- 统计引擎 ---
+
+// loadUserStats 从 DB 加载用户统计缓存到内存
+func loadUserStats() {
+	userStatsCache = make(map[int64]UserStatsEntry)
+	if err := db.Read("datas", "user_stats", &userStatsCache); err != nil {
+		fmt.Println("用户统计数据不存在或加载失败，初始化为空")
+		userStatsCache = make(map[int64]UserStatsEntry)
+	}
+	fmt.Printf("已加载 %d 条用户统计\n", len(userStatsCache))
+}
+
+// saveUserStats 持久化用户统计缓存到 DB
+func saveUserStats() {
+	if err := db.Write("datas", "user_stats", userStatsCache); err != nil {
+		fmt.Println("保存用户统计失败:", err)
+	}
+}
+
+// computeUserStats 全量计算指定用户的统计信息
+func computeUserStats(userID int64) UserStatsEntry {
+	today := time.Now().Format("2006-01-02")
+	entry := UserStatsEntry{
+		DailyCounts: make(map[string]int),
+		ComputedAt:  time.Now().Format(gTimeFormat),
+	}
+
+	// 从 streak 获取基础数据
+	if s, ok := laoHL.userStreak[userID]; ok {
+		entry.TotalCount = s.All
+		entry.StreakCount = s.Weeks
+		entry.CurrentStreak = s.Streak
+		entry.LastFortuneDate = s.Date
+	}
+
+	// 扫描历史文件（最近 30 天）
+	historyDir := "../db/history"
+	entries, err := os.ReadDir(historyDir)
+	if err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".json") {
+				continue
+			}
+			dateStr := strings.TrimSuffix(name, ".json")
+			fileDate, err := time.Parse("2006-01-02", dateStr)
+			if err != nil {
+				continue
+			}
+			if time.Since(fileDate) > 30*24*time.Hour {
+				continue
+			}
+			var cache laohuangliCache
+			data, err := os.ReadFile(filepath.Join(historyDir, name))
+			if err != nil {
+				continue
+			}
+			if err := json.Unmarshal(data, &cache); err != nil {
+				continue
+			}
+			// history JSON 的 caches key 是 string 形式的 user ID
+			if _, ok := cache.Caches[userID]; ok {
+				entry.DailyCounts[dateStr]++
+			}
+		}
+	}
+
+	// 检查今日缓存
+	if laoHL.cache.Date == today {
+		if _, ok := laoHL.cache.Caches[userID]; ok {
+			entry.DailyCounts[today]++
+		}
+	}
+
+	// 计算 last_month_count
+	entry.LastMonthCount = 0
+	for _, count := range entry.DailyCounts {
+		entry.LastMonthCount += count
+	}
+
+	return entry
+}
+
+// updateUserStatsOnFortune 算命成功后增量更新用户统计
+func updateUserStatsOnFortune(userID int64) {
+	today := time.Now().Format("2006-01-02")
+
+	userStatsMu.Lock()
+	defer userStatsMu.Unlock()
+
+	entry, ok := userStatsCache[userID]
+	if !ok {
+		entry = UserStatsEntry{
+			DailyCounts: make(map[string]int),
+			ComputedAt:  time.Now().Format(gTimeFormat),
+		}
+	}
+
+	// 从 streak 同步最新数据
+	if s, ok := laoHL.userStreak[userID]; ok {
+		entry.TotalCount = s.All
+		entry.StreakCount = s.Weeks
+		entry.CurrentStreak = s.Streak
+		entry.LastFortuneDate = s.Date
+	}
+
+	entry.DailyCounts[today]++
+	entry.LastMonthCount++
+	entry.ComputedAt = time.Now().Format(gTimeFormat)
+
+	userStatsCache[userID] = entry
+	saveUserStats()
+}
+
+// expireUserStatsDaily 每日零点清理过期的每日统计
+func expireUserStatsDaily() {
+	userStatsMu.Lock()
+	defer userStatsMu.Unlock()
+
+	cutoff := time.Now().AddDate(0, 0, -30).Format("2006-01-02")
+	dirty := false
+	for uid, entry := range userStatsCache {
+		total := 0
+		for date, count := range entry.DailyCounts {
+			if date < cutoff {
+				delete(entry.DailyCounts, date)
+				dirty = true
+			} else {
+				total += count
+			}
+		}
+		entry.LastMonthCount = total
+		entry.ComputedAt = time.Now().Format(gTimeFormat)
+		userStatsCache[uid] = entry
+	}
+	if dirty {
+		saveUserStats()
+	}
+}
+
+// handleUserStats 用户统计 API handler
+func handleUserStats(c fiber.Ctx) error {
+	idStr := c.Params("id")
+	userID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "无效的用户 ID"})
+	}
+
+	// 检查用户是否存在
+	if _, ok := laoHL.userStreak[userID]; !ok {
+		// 检查历史记录中是否有该用户
+		found := false
+		historyDir := "../db/history"
+		if dirEntries, err := os.ReadDir(historyDir); err == nil {
+			for _, e := range dirEntries {
+				name := e.Name()
+				if !strings.HasSuffix(name, ".json") {
+					continue
+				}
+				fileDate, _ := time.Parse("2006-01-02", strings.TrimSuffix(name, ".json"))
+				if time.Since(fileDate) > 30*24*time.Hour {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(historyDir, name))
+				if err != nil {
+					continue
+				}
+				var cache laohuangliCache
+				if err := json.Unmarshal(data, &cache); err != nil {
+					continue
+				}
+				if _, ok := cache.Caches[userID]; ok {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "用户不存在或从未算命"})
+		}
+	}
+
+	// 优先使用缓存，缓存不存在则全量计算
+	userStatsMu.RLock()
+	entry, ok := userStatsCache[userID]
+	userStatsMu.RUnlock()
+
+	if !ok {
+		entry = computeUserStats(userID)
+		userStatsMu.Lock()
+		userStatsCache[userID] = entry
+		saveUserStats()
+		userStatsMu.Unlock()
+	}
+
+	return c.JSON(fiber.Map{
+		"user_id":           idStr,
+		"total_count":       entry.TotalCount,
+		"streak_count":      entry.StreakCount,
+		"current_streak":    entry.CurrentStreak,
+		"last_month_count":  entry.LastMonthCount,
+		"last_fortune_date": entry.LastFortuneDate,
+	})
+}

--- a/tgbot/laohuangli.go
+++ b/tgbot/laohuangli.go
@@ -385,6 +385,7 @@ func (lhl *laohuangli) randomToday(id int64, name string) string {
 	}
 	lhl.cache.Push(id, name, head+body)
 	lhl.cache.Save()
+	go updateUserStatsOnFortune(id)
 	return head + body
 }
 func (lhl *laohuangli) update() {
@@ -399,6 +400,7 @@ func (lhl *laohuangli) update() {
 			lhl.cache.Save()
 			lhl.createBanlancedEntries()
 			lhl.db.Write("datas", "streak", lhl.userStreak)
+			go expireUserStatsDaily()
 		}
 	}
 }

--- a/tgbot/main.go
+++ b/tgbot/main.go
@@ -65,6 +65,10 @@ func SetupApp() {
 	// 加载配置（优先 DB，否则从环境变量初始化）
 	loadConfig()
 
+	// 加载 API Token 和用户统计缓存
+	loadAPITokens()
+	loadUserStats()
+
 	// 从配置中读取运行时变量
 	gToken = GetBotToken()
 	gAdminID = GetAdminID()

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -8,13 +8,10 @@
 
 	import { onMount, onDestroy } from 'svelte';
 	import { invalidateAll } from '$app/navigation';
-	async function dataUpdate() {
-		invalidateAll();
-	}
 	let update;
 	onMount(() => {
 		update = setInterval(() => {
-			dataUpdate();
+			invalidateAll();
 		}, 120000);
 	});
 	onDestroy(() => {

--- a/website/src/routes/admin/+layout.svelte
+++ b/website/src/routes/admin/+layout.svelte
@@ -15,6 +15,9 @@
 			<li>
 				<a href="/admin/logs" class:active={currentPath === '/admin/logs'}> 📋 日志查看 </a>
 			</li>
+			<li>
+				<a href="/admin/tokens" class:active={currentPath === '/admin/tokens'}> 🔑 API Token </a>
+			</li>
 		</ul>
 		<div class="divider"></div>
 		<a href="/" class="btn btn-ghost btn-sm">← 返回首页</a>

--- a/website/src/routes/admin/tokens/+page.svelte
+++ b/website/src/routes/admin/tokens/+page.svelte
@@ -1,0 +1,173 @@
+<script>
+	import { onMount } from 'svelte';
+
+	let tokens = [];
+	let loading = true;
+	let error = '';
+	let success = '';
+	let newName = '';
+	let createdToken = '';
+
+	onMount(() => {
+		loadTokens();
+	});
+
+	async function loadTokens() {
+		const token = localStorage.getItem('auth_token');
+		loading = true;
+		try {
+			const res = await fetch('/api/admin/tokens', {
+				headers: { Authorization: `Bearer ${token}` }
+			});
+			if (res.ok) {
+				const data = await res.json();
+				tokens = data.tokens || [];
+			} else {
+				error = '加载 Token 列表失败';
+			}
+		} catch (e) {
+			error = '连接服务器失败';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function handleCreate() {
+		const token = localStorage.getItem('auth_token');
+		error = '';
+		success = '';
+		createdToken = '';
+		try {
+			const res = await fetch('/api/admin/tokens', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${token}`
+				},
+				body: JSON.stringify({ name: newName.trim() || '未命名 Token' })
+			});
+			if (res.ok) {
+				const data = await res.json();
+				createdToken = data.token;
+				success = `Token "${data.name}" 已创建，请立即复制保存，关闭后将无法再次查看完整 Token。`;
+				newName = '';
+				loadTokens();
+			} else {
+				error = '创建 Token 失败';
+			}
+		} catch (e) {
+			error = '连接服务器失败';
+		}
+	}
+
+	async function handleDelete(id, name) {
+		if (!confirm(`确认删除 Token "${name}"？此操作不可撤销。`)) return;
+		const token = localStorage.getItem('auth_token');
+		error = '';
+		success = '';
+		try {
+			const res = await fetch(`/api/admin/tokens/${id}`, {
+				method: 'DELETE',
+				headers: { Authorization: `Bearer ${token}` }
+			});
+			if (res.ok) {
+				success = 'Token 已删除';
+				loadTokens();
+			} else {
+				error = '删除 Token 失败';
+			}
+		} catch (e) {
+			error = '连接服务器失败';
+		}
+	}
+
+	function copyToClipboard(text) {
+		navigator.clipboard.writeText(text).then(() => {
+			success = '已复制到剪贴板';
+		});
+	}
+</script>
+
+<div class="max-w-3xl">
+	<h1 class="text-2xl font-bold mb-6">API Token 管理</h1>
+
+	{#if error}
+		<div class="alert alert-error mb-4">
+			<span>{error}</span>
+		</div>
+	{/if}
+	{#if success}
+		<div class="alert alert-success mb-4">
+			<span>{success}</span>
+		</div>
+	{/if}
+
+	{#if createdToken}
+		<div class="alert alert-warning mb-4 flex-col items-start gap-2">
+			<span class="font-bold">请立即复制保存此 Token（仅显示一次）：</span>
+			<div class="flex items-center gap-2 w-full">
+				<code class="text-sm bg-base-300 px-2 py-1 rounded flex-1 break-all">{createdToken}</code>
+				<button class="btn btn-sm btn-outline" on:click={() => copyToClipboard(createdToken)}>
+					复制
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	<!-- 创建新 Token -->
+	<div class="card bg-base-200 mb-6">
+		<div class="card-body">
+			<h2 class="card-title text-lg">生成新 Token</h2>
+			<form on:submit|preventDefault={handleCreate} class="flex gap-2">
+				<input
+					bind:value={newName}
+					type="text"
+					placeholder="Token 名称（可选）"
+					class="input input-bordered flex-1"
+				/>
+				<button type="submit" class="btn btn-primary">生成</button>
+			</form>
+		</div>
+	</div>
+
+	<!-- Token 列表 -->
+	{#if loading}
+		<div class="flex justify-center py-8">
+			<span class="loading loading-spinner loading-lg"></span>
+		</div>
+	{:else if tokens.length === 0}
+		<div class="text-center py-8 text-base-content/50">暂无 API Token</div>
+	{:else}
+		<div class="overflow-x-auto">
+			<table class="table table-zebra">
+				<thead>
+					<tr>
+						<th>名称</th>
+						<th>Token</th>
+						<th>创建时间</th>
+						<th>操作</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each tokens as t}
+						<tr>
+							<td>{t.name || '未命名'}</td>
+							<td>
+								<code class="text-xs">{t.token}</code>
+							</td>
+							<td class="text-sm">{t.created_at}</td>
+							<td>
+								<button
+									class="btn btn-sm btn-error btn-outline"
+									on:click={() => handleDelete(t.id, t.name)}
+								>
+									删除
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>

--- a/website/src/routes/livings.svelte
+++ b/website/src/routes/livings.svelte
@@ -11,7 +11,7 @@
 		livingPool.splice(0, livingPool.length);
 		for (const k in cache) {
 			let one = { id: k, ...cache[k] };
-			if (!livingPool.hasOwnProperty(k)) {
+			if (!Object.prototype.hasOwnProperty.call(livingPool, k)) {
 				livingPool.push(one);
 			}
 		}
@@ -65,10 +65,6 @@
 	onDestroy(() => {
 		clearInterval(roller);
 	});
-	export async function load({ parent }) {
-		const { a, b } = await parent();
-		return { c: a + b };
-	}
 </script>
 
 <div class="select-none text-xl lg:text-3xl text-center font-bold">众生</div>


### PR DESCRIPTION
…I token/user stats

- Add BrowserOnlyMiddleware to validate Sec-Fetch-Site header (Forbidden Header, JS cannot forge)
- Restore /api/cache, /api/templates, /api/entries with BrowserOnlyMiddleware + rate limiter dual protection
- Add /api/today endpoint returning fortune count
- Add API Token CRUD and user statistics system (apiext.go)
- Restore frontend Today/Livings components for homepage
- Add admin API Token management page
- Document all API endpoints in README.md
- Sync AGENTS.md with current architecture