### PR TITLE
feat: monthly history archive

### DIFF
--- a/tgbot/apiext.go
+++ b/tgbot/apiext.go
@@ -3,10 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -205,34 +202,10 @@ func computeUserStats(userID int64) UserStatsEntry {
 	}
 
 	// 扫描历史文件（最近 30 天）
-	historyDir := "../db/history"
-	entries, err := os.ReadDir(historyDir)
-	if err == nil {
-		for _, e := range entries {
-			name := e.Name()
-			if !strings.HasSuffix(name, ".json") {
-				continue
-			}
-			dateStr := strings.TrimSuffix(name, ".json")
-			fileDate, err := time.Parse("2006-01-02", dateStr)
-			if err != nil {
-				continue
-			}
-			if time.Since(fileDate) > 30*24*time.Hour {
-				continue
-			}
-			var cache laohuangliCache
-			data, err := os.ReadFile(filepath.Join(historyDir, name))
-			if err != nil {
-				continue
-			}
-			if err := json.Unmarshal(data, &cache); err != nil {
-				continue
-			}
-			// history JSON 的 caches key 是 string 形式的 user ID
-			if _, ok := cache.Caches[userID]; ok {
-				entry.DailyCounts[dateStr]++
-			}
+	entries := readHistoryEntries("../db/history", time.Now().AddDate(0, 0, -30))
+	for dateStr, cache := range entries {
+		if _, ok := cache.Caches[userID]; ok {
+			entry.DailyCounts[dateStr]++
 		}
 	}
 
@@ -319,31 +292,12 @@ func handleUserStats(c fiber.Ctx) error {
 
 	// 检查用户是否存在
 	if _, ok := laoHL.userStreak[userID]; !ok {
-		// 检查历史记录中是否有该用户
 		found := false
-		historyDir := "../db/history"
-		if dirEntries, err := os.ReadDir(historyDir); err == nil {
-			for _, e := range dirEntries {
-				name := e.Name()
-				if !strings.HasSuffix(name, ".json") {
-					continue
-				}
-				fileDate, _ := time.Parse("2006-01-02", strings.TrimSuffix(name, ".json"))
-				if time.Since(fileDate) > 30*24*time.Hour {
-					continue
-				}
-				data, err := os.ReadFile(filepath.Join(historyDir, name))
-				if err != nil {
-					continue
-				}
-				var cache laohuangliCache
-				if err := json.Unmarshal(data, &cache); err != nil {
-					continue
-				}
-				if _, ok := cache.Caches[userID]; ok {
-					found = true
-					break
-				}
+		entries := readHistoryEntries("../db/history", time.Now().AddDate(0, 0, -30))
+		for _, cache := range entries {
+			if _, ok := cache.Caches[userID]; ok {
+				found = true
+				break
 			}
 		}
 		if !found {

--- a/tgbot/history.go
+++ b/tgbot/history.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type monthlyArchive map[string]laohuangliCache
+
+var historyMu sync.RWMutex
+
+// archiveMonthly 归档所有非当月的 history 日文件为月度归档文件
+func archiveMonthly(historyDir string) {
+	historyMu.Lock()
+	defer historyMu.Unlock()
+
+	currentMonth := time.Now().Format("2006-01")
+
+	dirEntries, err := os.ReadDir(historyDir)
+	if err != nil {
+		fmt.Println("归档: 读取 history 目录失败:", err)
+		return
+	}
+
+	monthGroups := make(map[string][]string)
+	for _, e := range dirEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		dateStr := strings.TrimSuffix(e.Name(), ".json")
+		fileDate, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		month := fileDate.Format("2006-01")
+		if month >= currentMonth {
+			continue
+		}
+		monthGroups[month] = append(monthGroups[month], dateStr)
+	}
+
+	if len(monthGroups) == 0 {
+		return
+	}
+
+	for month, dates := range monthGroups {
+		archive := make(monthlyArchive)
+		for _, dateStr := range dates {
+			var cache laohuangliCache
+			data, err := os.ReadFile(filepath.Join(historyDir, dateStr+".json"))
+			if err != nil {
+				fmt.Printf("归档: 读取 %s.json 失败: %v\n", dateStr, err)
+				continue
+			}
+			if err := json.Unmarshal(data, &cache); err != nil {
+				fmt.Printf("归档: 解析 %s.json 失败: %v\n", dateStr, err)
+				continue
+			}
+			archive[dateStr] = cache
+		}
+
+		if len(archive) == 0 {
+			continue
+		}
+
+		outPath := filepath.Join(historyDir, month+".json")
+		if existingData, err := os.ReadFile(outPath); err == nil {
+			var existing monthlyArchive
+			if json.Unmarshal(existingData, &existing) == nil {
+				for k, v := range existing {
+					if _, ok := archive[k]; !ok {
+						archive[k] = v
+					}
+				}
+			}
+		}
+
+		archiveData, err := json.Marshal(archive)
+		if err != nil {
+			fmt.Printf("归档: 序列化 %s 失败: %v\n", month, err)
+			continue
+		}
+		if err := os.WriteFile(outPath, archiveData, 0o644); err != nil {
+			fmt.Printf("归档: 写入 %s.json 失败: %v\n", month, err)
+			continue
+		}
+
+		for dateStr := range archive {
+			os.Remove(filepath.Join(historyDir, dateStr+".json"))
+		}
+		fmt.Printf("归档: %s 完成，%d 个日文件\n", month, len(archive))
+	}
+}
+
+// readHistoryEntries 读取 cutoff 之后的所有 history 条目（兼容日文件 + 月归档）
+func readHistoryEntries(historyDir string, cutoff time.Time) map[string]laohuangliCache {
+	historyMu.RLock()
+	defer historyMu.RUnlock()
+
+	result := make(map[string]laohuangliCache)
+
+	dirEntries, err := os.ReadDir(historyDir)
+	if err != nil {
+		return result
+	}
+
+	cutoffMonth := cutoff.Format("2006-01")
+	for _, e := range dirEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := e.Name()
+		base := strings.TrimSuffix(name, ".json")
+
+		if _, err := time.Parse("2006-01", base); err == nil {
+			if base < cutoffMonth {
+				continue
+			}
+			var archive monthlyArchive
+			data, err := os.ReadFile(filepath.Join(historyDir, name))
+			if err != nil {
+				continue
+			}
+			if err := json.Unmarshal(data, &archive); err != nil {
+				continue
+			}
+			for dateStr, cache := range archive {
+				fileDate, err := time.Parse("2006-01-02", dateStr)
+				if err != nil {
+					continue
+				}
+				if fileDate.After(cutoff) || fileDate.Equal(cutoff) {
+					result[dateStr] = cache
+				}
+			}
+			continue
+		}
+
+		fileDate, err := time.Parse("2006-01-02", base)
+		if err != nil {
+			continue
+		}
+		if fileDate.Before(cutoff) {
+			continue
+		}
+		var cache laohuangliCache
+		data, err := os.ReadFile(filepath.Join(historyDir, name))
+		if err != nil {
+			continue
+		}
+		if err := json.Unmarshal(data, &cache); err != nil {
+			continue
+		}
+		result[base] = cache
+	}
+
+	return result
+}

--- a/tgbot/laohuangli.go
+++ b/tgbot/laohuangli.go
@@ -34,6 +34,8 @@ type laohuangli struct {
 	templates  map[string]laohuangliTemplate
 	cache      laohuangliCache
 	annual     map[string]AnnualSummary
+	// 月度归档幂等标记
+	lastArchivedMonth string
 }
 
 var laoHL laohuangli
@@ -401,6 +403,17 @@ func (lhl *laohuangli) update() {
 			lhl.createBanlancedEntries()
 			lhl.db.Write("datas", "streak", lhl.userStreak)
 			go expireUserStatsDaily()
+
+			now := time.Now()
+			if now.Day() == 1 {
+				currentMonth := now.Format("2006-01")
+				if lhl.lastArchivedMonth != currentMonth {
+					lhl.lastArchivedMonth = currentMonth
+					go archiveMonthly("../db/history")
+				}
+			} else {
+				lhl.lastArchivedMonth = ""
+			}
 		}
 	}
 }

--- a/tgbot/tools/annualgen/main.go
+++ b/tgbot/tools/annualgen/main.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	scribble "github.com/nanobox-io/golang-scribble"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -91,11 +90,6 @@ func main() {
 		*outPath = filepath.Join(*dbPath, "annual", fmt.Sprintf("%d.json", *year))
 	}
 
-	db, err := scribble.New(*dbPath, nil)
-	if err != nil {
-		exitWithError(fmt.Errorf("初始化 db 失败: %w", err))
-	}
-
 	llmClient, err := newLLMClient()
 	if err != nil {
 		exitWithError(err)
@@ -113,7 +107,7 @@ func main() {
 		return
 	}
 
-	annual, stats, err := buildAnnualSummary(db, *dbPath, *outPath, *year, *threshold, *maxCandidates, llmClient, *fallbackPath)
+	annual, stats, err := buildAnnualSummary(*dbPath, *outPath, *year, *threshold, *maxCandidates, llmClient, *fallbackPath)
 	if err != nil {
 		exitWithError(err)
 	}
@@ -155,12 +149,8 @@ func newLLMClient() (*LLMClient, error) {
 	}, nil
 }
 
-func buildAnnualSummary(db *scribble.Driver, dbPath string, outPath string, year int, threshold int, maxCandidates int, llm *LLMClient, fallbackPath string) (map[string]AnnualSummary, []AnnualUserStats, error) {
+func buildAnnualSummary(dbPath string, outPath string, year int, threshold int, maxCandidates int, llm *LLMClient, fallbackPath string) (map[string]AnnualSummary, []AnnualUserStats, error) {
 	historyDir := filepath.Join(dbPath, "history")
-	files, err := os.ReadDir(historyDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("读取 history 目录失败: %w", err)
-	}
 
 	annual := make(map[string]AnnualSummary)
 	if existing, err := loadAnnualFile(outPath); err == nil {
@@ -168,20 +158,10 @@ func buildAnnualSummary(db *scribble.Driver, dbPath string, outPath string, year
 	}
 
 	statsMap := make(map[int64]*AnnualUserStats)
-	yearlyDates := make([]string, 0)
-	for _, f := range files {
-		if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
-			continue
-		}
-		dateStr := strings.TrimSuffix(f.Name(), ".json")
-		if !isDateInYear(dateStr, year) {
-			continue
-		}
+	allEntries := readHistoryEntriesForYear(historyDir, year)
+	yearlyDates := make([]string, 0, len(allEntries))
+	for dateStr, cache := range allEntries {
 		yearlyDates = append(yearlyDates, dateStr)
-		var cache laohuangliCache
-		if err := db.Read("history", dateStr, &cache); err != nil {
-			return nil, nil, fmt.Errorf("读取 history/%s 失败: %w", dateStr, err)
-		}
 		for id, result := range cache.Caches {
 			stat := getOrInitStats(statsMap, id, result.Name)
 			stat.ActiveDays++
@@ -469,12 +449,63 @@ func randomFallback(fallbacks []string) string {
 	return fallbacks[rand.IntN(len(fallbacks))]
 }
 
-func isDateInYear(dateStr string, year int) bool {
-	t, err := time.Parse("2006-01-02", dateStr)
+type monthlyArchive map[string]laohuangliCache
+
+func readHistoryEntriesForYear(historyDir string, year int) map[string]laohuangliCache {
+	result := make(map[string]laohuangliCache)
+
+	dirEntries, err := os.ReadDir(historyDir)
 	if err != nil {
-		return false
+		return result
 	}
-	return t.Year() == year
+
+	for _, e := range dirEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := e.Name()
+		base := strings.TrimSuffix(name, ".json")
+
+		if _, err := time.Parse("2006-01", base); err == nil {
+			var archive monthlyArchive
+			data, err := os.ReadFile(filepath.Join(historyDir, name))
+			if err != nil {
+				continue
+			}
+			if err := json.Unmarshal(data, &archive); err != nil {
+				continue
+			}
+			for dateStr, cache := range archive {
+				t, err := time.Parse("2006-01-02", dateStr)
+				if err != nil {
+					continue
+				}
+				if t.Year() == year {
+					result[dateStr] = cache
+				}
+			}
+			continue
+		}
+
+		fileDate, err := time.Parse("2006-01-02", base)
+		if err != nil {
+			continue
+		}
+		if fileDate.Year() != year {
+			continue
+		}
+		var cache laohuangliCache
+		data, err := os.ReadFile(filepath.Join(historyDir, name))
+		if err != nil {
+			continue
+		}
+		if err := json.Unmarshal(data, &cache); err != nil {
+			continue
+		}
+		result[base] = cache
+	}
+
+	return result
 }
 
 func writeJSON(path string, data any) error {


### PR DESCRIPTION
## Summary
- Archive completed months' daily history files (`YYYY-MM-DD.json`) into monthly archive files (`YYYY-MM.json`) on the 1st of each month, reducing `db/history/` file count from ~838 to ~30+current month
- New `tgbot/history.go` provides unified `readHistoryEntries()` that transparently reads both daily files and monthly archives
- Rewires `computeUserStats()`, `handleUserStats()`, and `buildAnnualSummary()` to use the new reader

## Key design decisions
- **Crash-safe**: merges with existing archive before overwriting; only deletes daily files confirmed in the archive
- **Concurrent-safe**: `sync.RWMutex` protects against API reads during archive writes
- **Performance**: skips monthly archive files whose filename month is entirely before the cutoff
- **Idempotent**: `lastArchivedMonth` in-memory guard prevents redundant archiving on every 5s tick
- **annualgen**: removed `scribble` dependency, uses `readHistoryEntriesForYear()` (duplicated per project convention)