### PR TITLE
feat: multi-model OpenAI rotation with per-model backoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@
 ### 关键模块
 
 - **`laohuangli.go`** — 核心引擎：词条库加载、加权均衡随机抽取、模板渲染、每日缓存、今日指引生成
-- **`artificialIdiot.go`** — AI 内容生成：OpenAI API 调用、内容池管理（整点切换 + 预取）、prompt 构造；支持 `reloadAIConfig()` 热重载
-- **`config.go`** — 配置管理：从 scribble DB 读写配置，首次启动从环境变量初始化，支持运行时更新；Bot Token 和 Admin ID 变更后通过 `restartBot()` 热重载，无需手动重启。新增 `WebDomain` 字段用于 Webhook 域名配置
+- **`artificialIdiot.go`** — AI 内容生成：OpenAI API 调用、内容池管理（整点切换 + 预取）、prompt 构造；支持 `reloadAIConfig()` 热重载；`openai_model` 可配置多个模型（逗号/换行分隔），调用时轮换，失败立即切下一模型，各模型独立指数退避（30s→16min）
+- **`config.go`** — 配置管理：从 scribble DB 读写配置，首次启动从环境变量初始化，支持运行时更新；Bot Token 和 Admin ID 变更后通过 `restartBot()` 热重载，无需手动重启。新增 `WebDomain` 字段用于 Webhook 域名配置；`GetOpenAIModels()` 解析多模型列表
 - **`api.go`** — Fiber 路由注册：公开端点（`/api/today`、`/api/cache`、`/api/templates`、`/api/entries`，`BrowserOnlyMiddleware` Sec-Fetch-Site 校验 + 速率限制 5 次/分钟/IP 双重防护）、认证端点（`/api/auth/login`）、管理端点（`/api/admin/config`、`/api/admin/logs`、`/api/admin/tokens`）、用户统计端点（`/api/user/:id/stats`）、Webhook 端点（`/webhook`）、SPA fallback（`/*`）。使用 Fiber 中间件做 JWT 认证、API Token 认证、浏览器校验和速率限制
 - **`apiext.go`** — API Token 管理与用户统计：Token CRUD（生成/删除/列表/验证）、`APITokenMiddleware` 中间件、用户统计引擎（全量扫描 history + 增量更新）、统计缓存（内存 + scribble DB `datas/user_stats`）。`expireUserStatsDaily()` 在每日零点清理过期统计，`updateUserStatsOnFortune()` 在算命成功后增量更新
 - **`main.go`** — 应用入口：Fiber app 初始化、`go:embed` 嵌入前端静态文件、Telegram Bot 启动（Webhook 或 Long Polling 降级）、启动时加载 API Token 和用户统计缓存
@@ -65,7 +65,7 @@
 - **样式**：TailwindCSS + DaisyUI 组件库
 - **代码规范**：Prettier + ESLint（`npm run lint` / `npm run format`）
 - **数据获取**：通过 `+page.js` 客户端 load 函数调用 Go 后端 API（`/api/cache`、`/api/templates`、`/api/entries`），API 路径为相对路径（同源）
-- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看、API Token 管理），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向
+- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看、API Token 管理），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向；AI 模型支持多行输入（每行一个）
 - **SSR**：全局禁用（`+layout.js` 中 `export const ssr = false`）
 
 ### 部署与构建
@@ -84,6 +84,7 @@
 - **提名限制**：每用户同时进行中的提名不超过 **5 条**
 - **投票规则**：≥5 赞成票且赞成率 >66% 为通过；≥7 票且赞成率 >75% 为快速通过；≥5 票且反对多于赞成 为快速否决
 - **AI 内容池**：每小时刷新，池上限 20 条，常规模式池 <5 时触发更新，59 分进入预取模式
+- **AI 多模型**：`openai_model` 支持多个模型（逗号/分号/换行分隔）；后端轮换调用，报错立即尝试下一个；每个模型的重试退避单独计算（初始 30s，翻倍至上限 16min）
 - **今日缓存**：每日零点自动失效，缓存结果按用户 ID 存储，同一用户当天结果不变
 
 ## ⚠️ 自我进化约束（Critical Self-Sync Rule）

--- a/tgbot/artificialIdiot.go
+++ b/tgbot/artificialIdiot.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"math/rand/v2"
@@ -59,6 +60,39 @@ func AIContentPush(pool *[]string, s string) {
 
 var aiContext, cancelAI = context.WithCancel(context.Background())
 
+// 每个模型独立退避；轮换下标跨次调用延续
+type openaiModelState struct {
+	nextRetry    time.Time
+	failureDelay time.Duration
+}
+
+var (
+	openaiModelMu     sync.Mutex
+	openaiModelStates = map[string]*openaiModelState{}
+	openaiNextIdx     int
+)
+
+const (
+	openaiInitialBackoff = 30 * time.Second
+	openaiMaxBackoff     = 16 * time.Minute
+)
+
+func resetOpenAIModelStates() {
+	openaiModelMu.Lock()
+	defer openaiModelMu.Unlock()
+	openaiModelStates = make(map[string]*openaiModelState)
+	openaiNextIdx = 0
+}
+
+func modelStateLocked(name string) *openaiModelState {
+	st, ok := openaiModelStates[name]
+	if !ok {
+		st = &openaiModelState{failureDelay: openaiInitialBackoff}
+		openaiModelStates[name] = st
+	}
+	return st
+}
+
 func initAIs() {
 	AIs = make([]*AIInstance, 0)
 	AIs = append(AIs, &AIInstance{
@@ -75,8 +109,6 @@ func initAIs() {
 		defer ticker.Stop()
 
 		lastHour := time.Now().Hour()
-		failureDelay := 30 * time.Second
-		var nextRegularUpdate time.Time
 
 		for {
 			select {
@@ -113,8 +145,8 @@ func initAIs() {
 						isPrefetch = true
 					}
 				} else {
-					// 常规模式：池不满 且 预取池为空 且 过了延迟时间
-					if len(AIContentPool) < 5 && len(AINextHourPool) == 0 && now.After(nextRegularUpdate) {
+					// 常规模式：池不满 且 预取池为空；退避由各模型自行计算
+					if len(AIContentPool) < 5 && len(AINextHourPool) == 0 {
 						targetPool = &AIContentPool
 						targetTime = now
 					}
@@ -134,20 +166,10 @@ func initAIs() {
 
 					if success {
 						fmt.Printf("AI content updated successfully (Prefetch: %v) at %s\n", isPrefetch, now.Format("15:04:05"))
-						failureDelay = 30 * time.Second
-						nextRegularUpdate = time.Time{} // 重置延迟
+					} else if isPrefetch {
+						fmt.Printf("Prefetch AI update failed at %s, will retry soon\n", now.Format("15:04:05"))
 					} else {
-						if !isPrefetch {
-							// 只有常规模式失败才增加延迟
-							fmt.Printf("Regular AI update failed at %s, retrying after %s\n", now.Format("15:04:05"), failureDelay)
-							nextRegularUpdate = now.Add(failureDelay)
-							failureDelay *= 2
-							if failureDelay > 16*time.Minute {
-								failureDelay = 16 * time.Minute
-							}
-						} else {
-							fmt.Printf("Prefetch AI update failed at %s, will retry soon\n", now.Format("15:04:05"))
-						}
+						fmt.Printf("Regular AI update failed at %s (per-model backoff)\n", now.Format("15:04:05"))
 					}
 				}
 			}
@@ -174,6 +196,7 @@ func initOpenAI(self *AIInstance) {
 		config.BaseURL = baseURL
 	}
 	openaiClient = openai.NewClientWithConfig(config)
+	resetOpenAIModelStates()
 	if getContentOpenAI(self, time.Now(), &AIContentPool) == nil {
 		self.Valid = true
 	} else {
@@ -216,31 +239,99 @@ func AISampleApped(s string) {
 	}
 }
 
+func configuredModels() []string {
+	models := GetOpenAIModels()
+	if len(models) == 0 {
+		return []string{openai.GPT4oMini}
+	}
+	return models
+}
+
 func getContentOpenAI(self *AIInstance, t time.Time, pool *[]string) (err error) {
-	prompt := make([]openai.ChatCompletionMessage, 0)
-	prompt = append(prompt, openai.ChatCompletionMessage{
+	models := configuredModels()
+	prompt := []openai.ChatCompletionMessage{{
 		Role:    openai.ChatMessageRoleUser,
 		Content: getPrompt(t),
+	}}
+	return rotateTryModels(models, func(model string) error {
+		return callOpenAIModel(model, prompt, self, pool)
 	})
+}
 
+// rotateTryModels 从 openaiNextIdx 起轮换；跳过退避中的模型；失败立即试下一个并单独退避
+func rotateTryModels(models []string, call func(string) error) error {
+	if len(models) == 0 {
+		return errors.New("no models")
+	}
+
+	openaiModelMu.Lock()
+	start := openaiNextIdx % len(models)
+	openaiModelMu.Unlock()
+
+	var lastErr error
+	tried := 0
+	now := time.Now()
+
+	for i := 0; i < len(models); i++ {
+		idx := (start + i) % len(models)
+		model := models[idx]
+
+		openaiModelMu.Lock()
+		st := modelStateLocked(model)
+		inBackoff := now.Before(st.nextRetry)
+		nextAt := st.nextRetry
+		openaiModelMu.Unlock()
+		if inBackoff {
+			fmt.Printf("skip model %s until %s\n", model, nextAt.Format("15:04:05"))
+			continue
+		}
+
+		tried++
+		err := call(model)
+		if err == nil {
+			openaiModelMu.Lock()
+			st = modelStateLocked(model)
+			st.failureDelay = openaiInitialBackoff
+			st.nextRetry = time.Time{}
+			openaiNextIdx = (idx + 1) % len(models)
+			openaiModelMu.Unlock()
+			return nil
+		}
+
+		lastErr = err
+		openaiModelMu.Lock()
+		st = modelStateLocked(model)
+		st.nextRetry = time.Now().Add(st.failureDelay)
+		fmt.Printf("model %s failed, next retry after %s (at %s)\n", model, st.failureDelay, st.nextRetry.Format("15:04:05"))
+		st.failureDelay *= 2
+		if st.failureDelay > openaiMaxBackoff {
+			st.failureDelay = openaiMaxBackoff
+		}
+		openaiModelMu.Unlock()
+	}
+
+	if tried == 0 {
+		return errors.New("all models in backoff")
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return errors.New("all models failed")
+}
+
+func callOpenAIModel(model string, prompt []openai.ChatCompletionMessage, self *AIInstance, pool *[]string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	req := openai.ChatCompletionRequest{
-		Model:    openai.GPT4oMini,
+		Model:    model,
 		Messages: prompt,
 		Stream:   false,
-	}
-	if model := GetOpenAIModel(); model != "" {
-		req.Model = model
 	}
 
 	reqJSON, _ := json.MarshalIndent(req, "", "  ")
 	fmt.Printf("即将发送的 JSON Payload:\n%s\n", string(reqJSON))
 
-	resp, err := openaiClient.CreateChatCompletion(
-		ctx,
-		req,
-	)
+	resp, err := openaiClient.CreateChatCompletion(ctx, req)
 	if err != nil {
 		e := &openai.APIError{}
 		if errors.As(err, &e) {
@@ -250,9 +341,7 @@ func getContentOpenAI(self *AIInstance, t time.Time, pool *[]string) (err error)
 				fmt.Printf("错误代码 (Code): %v\n", e.Code)
 				fmt.Printf("错误类型 (Type): %s\n", e.Type)
 				fmt.Printf("错误信息 (Message): %s\n", e.Message)
-
 				if e.Param != nil {
-					// 如果指针不为空，则解引用打印具体值
 					fmt.Printf("相关参数 (Param): %s\n", *e.Param)
 				} else {
 					fmt.Printf("相关参数 (Param): <null>\n")
@@ -263,7 +352,7 @@ func getContentOpenAI(self *AIInstance, t time.Time, pool *[]string) (err error)
 		} else {
 			fmt.Printf("Generic Error: %v\n", err)
 		}
-		return
+		return err
 	}
 
 	lines := strings.Split(resp.Choices[0].Message.Content, "\n")
@@ -275,7 +364,7 @@ func getContentOpenAI(self *AIInstance, t time.Time, pool *[]string) (err error)
 			fmt.Println(self.Name, "AI result add:", match[1], "to pool size:", len(*pool))
 		}
 	}
-	return err
+	return nil
 }
 
 func getPrompt(t time.Time) string {

--- a/tgbot/config.go
+++ b/tgbot/config.go
@@ -161,11 +161,36 @@ func GetOpenAIBaseURL() string {
 	return appConfig.OpenAIBaseURL
 }
 
-// GetOpenAIModel 获取 OpenAI 模型名称
+// GetOpenAIModel 获取 OpenAI 模型配置原文（可含多个，逗号/换行分隔）
 func GetOpenAIModel() string {
 	configMu.RLock()
 	defer configMu.RUnlock()
 	return appConfig.OpenAIModel
+}
+
+// parseOpenAIModels 将模型配置拆成列表（逗号、分号、换行分隔，去重保序）
+func parseOpenAIModels(raw string) []string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\r'
+	})
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, p := range parts {
+		m := strings.TrimSpace(p)
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+// GetOpenAIModels 获取 OpenAI 模型列表
+func GetOpenAIModels() []string {
+	configMu.RLock()
+	defer configMu.RUnlock()
+	return parseOpenAIModels(appConfig.OpenAIModel)
 }
 
 // UpdateConfig 更新配置（部分更新）

--- a/tgbot/openai_models_test.go
+++ b/tgbot/openai_models_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseOpenAIModels(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want []string
+	}{
+		{"", nil},
+		{"gpt-4o-mini", []string{"gpt-4o-mini"}},
+		{"gpt-4o-mini, gpt-4o", []string{"gpt-4o-mini", "gpt-4o"}},
+		{"a\nb\nc", []string{"a", "b", "c"}},
+		{"a;b, a\nc", []string{"a", "b", "c"}},
+		{"  x  ,\n y ", []string{"x", "y"}},
+	}
+	for _, tc := range cases {
+		got := parseOpenAIModels(tc.raw)
+		if len(got) != len(tc.want) {
+			t.Fatalf("parseOpenAIModels(%q) len=%d want %d (%v)", tc.raw, len(got), len(tc.want), got)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("parseOpenAIModels(%q)[%d]=%q want %q", tc.raw, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// ponytail: 不打真实 API；验证跳过退避模型、失败立即换下一个
+func TestOpenAIModelRotationBackoff(t *testing.T) {
+	resetOpenAIModelStates()
+	models := []string{"m1", "m2", "m3"}
+
+	openaiModelMu.Lock()
+	st1 := modelStateLocked("m1")
+	st1.nextRetry = time.Now().Add(time.Hour)
+	openaiNextIdx = 0
+	openaiModelMu.Unlock()
+
+	order := make([]string, 0)
+	err := rotateTryModels(models, func(model string) error {
+		order = append(order, model)
+		if model == "m2" {
+			return errors.New("fail m2")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(order) != 2 || order[0] != "m2" || order[1] != "m3" {
+		t.Fatalf("order=%v want [m2 m3] (skip m1 in backoff, fail m2, succeed m3)", order)
+	}
+
+	openaiModelMu.Lock()
+	defer openaiModelMu.Unlock()
+	if openaiNextIdx != 0 { // (m3 idx 2 + 1) % 3 == 0
+		t.Fatalf("openaiNextIdx=%d want 0", openaiNextIdx)
+	}
+	if !modelStateLocked("m2").nextRetry.After(time.Now()) {
+		t.Fatal("m2 should be in backoff after failure")
+	}
+	if !modelStateLocked("m3").nextRetry.IsZero() {
+		t.Fatal("m3 backoff should be cleared on success")
+	}
+}

--- a/website/src/routes/admin/+page.svelte
+++ b/website/src/routes/admin/+page.svelte
@@ -200,16 +200,21 @@
 					</div>
 					<div class="form-control">
 						<label class="label" for="openai_model">
-							<span class="label-text">OpenAI 模型</span>
-							<span class="label-text-alt">当前: {config.openai_model || 'gpt-4o-mini'}</span>
+							<span class="label-text">OpenAI 模型（可多个）</span>
+							<span class="label-text-alt"
+								>当前: {(config.openai_model || 'gpt-4o-mini').replace(/[\n\r;]+/g, ', ')}</span
+							>
 						</label>
-						<input
+						<textarea
 							id="openai_model"
 							bind:value={formData.openai_model}
-							type="text"
-							placeholder="留空不修改"
-							class="input input-bordered"
-						/>
+							placeholder={'每行一个模型，失败自动切换下一个\n例如:\ngpt-4o-mini\ngpt-4o'}
+							class="textarea textarea-bordered font-mono text-sm"
+							rows="4"
+						></textarea>
+						<label class="label" for="openai_model">
+							<span class="label-text-alt">留空不修改；多个模型会轮换调用，各自独立退避重试</span>
+						</label>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Admin AI settings accept multiple models (one per line / comma-separated)
- Backend rotates models; on error immediately tries the next one
- Each model keeps its own exponential backoff (30s → 16min)

## Test plan
- [ ] `go test -run 'TestParseOpenAIModels|TestOpenAIModelRotationBackoff' ./tgbot`
- [ ] In `/admin`, set 2+ models and save; confirm config reloads
- [ ] With a bad first model name, confirm logs show skip/failover to the next model

Made with [Cursor](https://cursor.com)