### PR TITLE
feat: batch AI content and curate quality samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,12 @@
 ### 关键模块
 
 - **`laohuangli.go`** — 核心引擎：词条库加载、加权均衡随机抽取、模板渲染、每日缓存、今日指引生成
-- **`artificialIdiot.go`** — AI 内容生成：OpenAI API 调用、内容池管理（整点切换 + 预取）、prompt 构造；支持 `reloadAIConfig()` 热重载；`openai_model` 可配置多个模型（逗号/换行分隔），调用时轮换，失败立即切下一模型，各模型独立指数退避（30s→16min）
+- **`artificialIdiot.go`** — AI 内容生成：OpenAI API 调用、6 小时分桶内容池和 60 条批量 prompt 构造；支持 `reloadAIConfig()` 热重载；`openai_model` 可配置多个模型（逗号/换行分隔），按配置优先级调用，首选不可用时才 fallback，各模型独立指数退避（30s→16min）
+- **`ai_curation.go`** — AI 词条管理：按小时内容池、最近 100 条生成结果及 good/bad 长期样本池的 scribble 持久化、并发保护和样本抽样
 - **`config.go`** — 配置管理：从 scribble DB 读写配置，首次启动从环境变量初始化，支持运行时更新；Bot Token 和 Admin ID 变更后通过 `restartBot()` 热重载，无需手动重启。新增 `WebDomain` 字段用于 Webhook 域名配置；`GetOpenAIModels()` 解析多模型列表
-- **`api.go`** — Fiber 路由注册：公开端点（`/api/today`、`/api/cache`、`/api/templates`、`/api/entries`，`BrowserOnlyMiddleware` Sec-Fetch-Site 校验 + 速率限制 5 次/分钟/IP 双重防护）、认证端点（`/api/auth/login`）、管理端点（`/api/admin/config`、`/api/admin/logs`、`/api/admin/tokens`）、用户统计端点（`/api/user/:id/stats`）、Webhook 端点（`/webhook`）、SPA fallback（`/*`）。使用 Fiber 中间件做 JWT 认证、API Token 认证、浏览器校验和速率限制
+- **`api.go`** — Fiber 路由注册：公开端点（`/api/today`、`/api/cache`、`/api/templates`、`/api/entries`，`BrowserOnlyMiddleware` Sec-Fetch-Site 校验 + 速率限制 5 次/分钟/IP 双重防护）、认证端点（`/api/auth/login`）、管理端点（配置、日志、API Token、AI 结果标注和词条库）、用户统计端点（`/api/user/:id/stats`）、Webhook 端点（`/webhook`）、SPA fallback（`/*`）。使用 Fiber 中间件做 JWT 认证、API Token 认证、浏览器校验和速率限制
 - **`apiext.go`** — API Token 管理与用户统计：Token CRUD（生成/删除/列表/验证）、`APITokenMiddleware` 中间件、用户统计引擎（全量扫描 history + 增量更新）、统计缓存（内存 + scribble DB `datas/user_stats`）。`expireUserStatsDaily()` 在每日零点清理过期统计，`updateUserStatsOnFortune()` 在算命成功后增量更新
-- **`main.go`** — 应用入口：Fiber app 初始化、`go:embed` 嵌入前端静态文件、Telegram Bot 启动（Webhook 或 Long Polling 降级）、启动时加载 API Token 和用户统计缓存
+- **`main.go`** — 应用入口：Fiber app 初始化、`go:embed` 嵌入前端静态文件、Telegram Bot 启动（Webhook 或 Long Polling 降级）、启动时加载 API Token、用户统计和 AI 词条库缓存
 - **`logbuffer.go`** — 日志缓冲：内存环形缓冲区 + 文件持久化，支持通过 API 远程查看日志
 - **`nominate.go`** — 词条提名与投票系统：赞成/反对、快速通过/否决、相似度查重（Jaro 算法）
 - **`chats.go`** — Telegram 私聊状态机（IDLE → NOMINATE）、命令路由、管理员权限
@@ -65,7 +66,7 @@
 - **样式**：TailwindCSS + DaisyUI 组件库
 - **代码规范**：Prettier + ESLint（`npm run lint` / `npm run format`）
 - **数据获取**：通过 `+page.js` 客户端 load 函数调用 Go 后端 API（`/api/cache`、`/api/templates`、`/api/entries`），API 路径为相对路径（同源）
-- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看、API Token 管理），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向；AI 模型支持多行输入（每行一个）
+- **管理后台**：`/login` 登录页 + `/admin` 管理路由组（配置编辑、日志查看、API Token、AI 结果标注和 good/bad 词条库管理），通过 localStorage 中的 JWT token 认证，客户端路由守卫（`+layout.js`）检查 token 有效性，未登录自动重定向；AI 模型支持多行输入（每行一个）
 - **SSR**：全局禁用（`+layout.js` 中 `export const ssr = false`）
 
 ### 部署与构建
@@ -83,8 +84,9 @@
 - **词条长度**：单条提名不超过 **64 个 Unicode 字符**
 - **提名限制**：每用户同时进行中的提名不超过 **5 条**
 - **投票规则**：≥5 赞成票且赞成率 >66% 为通过；≥7 票且赞成率 >75% 为快速通过；≥5 票且反对多于赞成 为快速否决
-- **AI 内容池**：每小时刷新，池上限 20 条，常规模式池 <5 时触发更新，59 分进入预取模式
-- **AI 多模型**：`openai_model` 支持多个模型（逗号/分号/换行分隔）；后端轮换调用，报错立即尝试下一个；每个模型的重试退避单独计算（初始 30s，翻倍至上限 16min）
+- **AI 内容池**：每次从当前小时起生成连续 6 小时、每小时 10 条，共 60 条；当前和下一小时剩余总数少于 3 时异步追加同规格批次；仅发放当前小时词条，过期桶会清理
+- **AI 多模型**：`openai_model` 支持多个模型（逗号/分号/换行分隔）；配置顺序即优先级，首选失败或退避时才依次 fallback；每个模型的重试退避单独计算（初始 30s，翻倍至上限 16min）
+- **AI 质量样本**：最近 100 条已接受结果持久化；管理员可将词条互斥标记为 good/bad。生成时随机取最多 40 条 good 和 10 条 bad，数量不足时以默认样本补齐
 - **今日缓存**：每日零点自动失效，缓存结果按用户 ID 存储，同一用户当天结果不变
 
 ## ⚠️ 自我进化约束（Critical Self-Sync Rule）

--- a/tgbot/ai_curation.go
+++ b/tgbot/ai_curation.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	aiHourLayout       = "2006-01-02 15"
+	aiBatchHours       = 6
+	aiEntriesPerHour   = 10
+	aiRefillThreshold  = 3
+	aiRecentResultSize = 100
+)
+
+type AIRecentResult struct {
+	Text        string `json:"text"`
+	Hour        string `json:"hour"`
+	GeneratedAt string `json:"generated_at"`
+}
+
+type AIContentStore struct {
+	Recent []AIRecentResult `json:"recent"`
+	Good   []string         `json:"good"`
+	Bad    []string         `json:"bad"`
+}
+
+var (
+	aiContentMu     sync.Mutex
+	aiHourlyContent = map[string][]string{}
+
+	aiStoreMu sync.RWMutex
+	aiStore   AIContentStore
+)
+
+func loadAIContentStore() {
+	aiStoreMu.Lock()
+	defer aiStoreMu.Unlock()
+
+	aiStore = AIContentStore{}
+	if err := db.Read("datas", "ai_content", &aiStore); err != nil {
+		fmt.Println("AI 词条库不存在或加载失败，初始化为空")
+	}
+	aiStore.Recent = trimRecent(aiStore.Recent)
+	aiStore.Good = uniqueAITexts(aiStore.Good)
+	aiStore.Bad = uniqueAITexts(aiStore.Bad)
+}
+
+func saveAIContentStoreLocked() {
+	if err := db.Write("datas", "ai_content", aiStore); err != nil {
+		fmt.Println("保存 AI 词条库失败:", err)
+	}
+}
+
+func trimRecent(entries []AIRecentResult) []AIRecentResult {
+	if len(entries) <= aiRecentResultSize {
+		return entries
+	}
+	return entries[len(entries)-aiRecentResultSize:]
+}
+
+func uniqueAITexts(texts []string) []string {
+	out := make([]string, 0, len(texts))
+	seen := make(map[string]bool, len(texts))
+	for _, text := range texts {
+		text = strings.TrimSpace(text)
+		if text == "" || seen[text] {
+			continue
+		}
+		seen[text] = true
+		out = append(out, text)
+	}
+	return out
+}
+
+func recordAIResults(entries []AIRecentResult) {
+	if len(entries) == 0 {
+		return
+	}
+	aiStoreMu.Lock()
+	aiStore.Recent = trimRecent(append(aiStore.Recent, entries...))
+	saveAIContentStoreLocked()
+	aiStoreMu.Unlock()
+}
+
+func recentAIResults() []AIRecentResult {
+	aiStoreMu.RLock()
+	defer aiStoreMu.RUnlock()
+	out := make([]AIRecentResult, len(aiStore.Recent))
+	for i := range aiStore.Recent {
+		out[len(aiStore.Recent)-1-i] = aiStore.Recent[i]
+	}
+	return out
+}
+
+func aiCuratedEntries(kind string) []string {
+	aiStoreMu.RLock()
+	defer aiStoreMu.RUnlock()
+	var source []string
+	if kind == "good" {
+		source = aiStore.Good
+	} else {
+		source = aiStore.Bad
+	}
+	return append([]string(nil), source...)
+}
+
+func aiCuratedLabels() map[string]string {
+	aiStoreMu.RLock()
+	defer aiStoreMu.RUnlock()
+	labels := make(map[string]string, len(aiStore.Good)+len(aiStore.Bad))
+	for _, text := range aiStore.Good {
+		labels[text] = "good"
+	}
+	for _, text := range aiStore.Bad {
+		labels[text] = "bad"
+	}
+	return labels
+}
+
+func labelAIEntry(text, kind string) error {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return fmt.Errorf("词条不能为空")
+	}
+	if len([]rune(text)) > 64 {
+		return fmt.Errorf("词条不能超过 64 个字符")
+	}
+	if kind != "good" && kind != "bad" {
+		return fmt.Errorf("无效标签")
+	}
+
+	aiStoreMu.Lock()
+	defer aiStoreMu.Unlock()
+	if err := setAIEntryLabel(&aiStore, text, kind); err != nil {
+		return err
+	}
+	saveAIContentStoreLocked()
+	return nil
+}
+
+func setAIEntryLabel(store *AIContentStore, text, kind string) error {
+	if kind == "good" {
+		store.Bad = removeAIText(store.Bad, text)
+		store.Good = addAIText(store.Good, text)
+	} else if kind == "bad" {
+		store.Good = removeAIText(store.Good, text)
+		store.Bad = addAIText(store.Bad, text)
+	} else {
+		return fmt.Errorf("无效标签")
+	}
+	return nil
+}
+
+func deleteAICuratedEntry(text, kind string) bool {
+	aiStoreMu.Lock()
+	defer aiStoreMu.Unlock()
+	var entries *[]string
+	if kind == "good" {
+		entries = &aiStore.Good
+	} else if kind == "bad" {
+		entries = &aiStore.Bad
+	} else {
+		return false
+	}
+	before := len(*entries)
+	*entries = removeAIText(*entries, text)
+	if before == len(*entries) {
+		return false
+	}
+	saveAIContentStoreLocked()
+	return true
+}
+
+func addAIText(texts []string, text string) []string {
+	for _, candidate := range texts {
+		if candidate == text {
+			return texts
+		}
+	}
+	return append(texts, text)
+}
+
+func removeAIText(texts []string, text string) []string {
+	for i, candidate := range texts {
+		if candidate == text {
+			return append(texts[:i], texts[i+1:]...)
+		}
+	}
+	return texts
+}
+
+func randomAIEntries(entries []string, n int) []string {
+	if n > len(entries) {
+		n = len(entries)
+	}
+	out := make([]string, 0, n)
+	for _, i := range cryptoPermutation(len(entries))[:n] {
+		out = append(out, entries[i])
+	}
+	return out
+}
+
+func cryptoPermutation(n int) []int {
+	indices := make([]int, n)
+	for i := range indices {
+		indices[i] = i
+	}
+	for i := n - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			j = big.NewInt(0)
+		}
+		indices[i], indices[j.Int64()] = indices[j.Int64()], indices[i]
+	}
+	return indices
+}
+
+func hourKey(t time.Time) string {
+	return t.Truncate(time.Hour).Format(aiHourLayout)
+}
+
+func nextHour(t time.Time) time.Time {
+	return t.Truncate(time.Hour).Add(time.Hour)
+}
+
+func aiContentNeedsRefill(t time.Time) bool {
+	aiContentMu.Lock()
+	defer aiContentMu.Unlock()
+	return len(aiHourlyContent[hourKey(t)])+len(aiHourlyContent[hourKey(nextHour(t))]) < aiRefillThreshold
+}
+
+func appendAIHourlyContent(entries []AIRecentResult) {
+	aiContentMu.Lock()
+	defer aiContentMu.Unlock()
+	for _, entry := range entries {
+		aiHourlyContent[entry.Hour] = append(aiHourlyContent[entry.Hour], entry.Text)
+	}
+}
+
+func pruneAIHourlyContent(now time.Time) {
+	current := hourKey(now)
+	aiContentMu.Lock()
+	defer aiContentMu.Unlock()
+	for hour := range aiHourlyContent {
+		if hour < current {
+			delete(aiHourlyContent, hour)
+		}
+	}
+}

--- a/tgbot/ai_curation_test.go
+++ b/tgbot/ai_curation_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseAIHourlyResults(t *testing.T) {
+	start := time.Date(2026, 7, 13, 16, 42, 0, 0, time.Local)
+	var content strings.Builder
+	for hourOffset := 0; hourOffset < aiBatchHours; hourOffset++ {
+		hour := hourKey(start.Add(time.Duration(hourOffset) * time.Hour))
+		for entryOffset := 0; entryOffset < aiEntriesPerHour; entryOffset++ {
+			fmt.Fprintf(&content, "[%s]{词条%d-%d}\n", hour, hourOffset, entryOffset)
+		}
+	}
+
+	results, err := parseAIHourlyResults(content.String(), start)
+	if err != nil {
+		t.Fatalf("parseAIHourlyResults returned error: %v", err)
+	}
+	if len(results) != aiBatchHours*aiEntriesPerHour {
+		t.Fatalf("got %d results, want %d", len(results), aiBatchHours*aiEntriesPerHour)
+	}
+}
+
+func TestAIContentNeedsRefill(t *testing.T) {
+	now := time.Date(2026, 7, 13, 16, 0, 0, 0, time.Local)
+	aiContentMu.Lock()
+	aiHourlyContent = map[string][]string{
+		hourKey(now):           {"a"},
+		hourKey(nextHour(now)): {"b"},
+	}
+	aiContentMu.Unlock()
+	if !aiContentNeedsRefill(now) {
+		t.Fatal("two current/next hour entries should trigger refill")
+	}
+
+	aiContentMu.Lock()
+	aiHourlyContent[hourKey(nextHour(now))] = append(aiHourlyContent[hourKey(nextHour(now))], "c")
+	aiContentMu.Unlock()
+	if aiContentNeedsRefill(now) {
+		t.Fatal("three current/next hour entries should not trigger refill")
+	}
+}
+
+func TestAIEntryLabelsAreMutuallyExclusive(t *testing.T) {
+	store := AIContentStore{Bad: []string{"好词条"}}
+	if err := setAIEntryLabel(&store, "好词条", "good"); err != nil {
+		t.Fatalf("set good label: %v", err)
+	}
+	if len(store.Good) != 1 || len(store.Bad) != 0 {
+		t.Fatalf("good=%v bad=%v, want [好词条] and []", store.Good, store.Bad)
+	}
+	if err := setAIEntryLabel(&store, "好词条", "bad"); err != nil {
+		t.Fatalf("set bad label: %v", err)
+	}
+	if len(store.Good) != 0 || len(store.Bad) != 1 {
+		t.Fatalf("good=%v bad=%v, want [] and [好词条]", store.Good, store.Bad)
+	}
+}

--- a/tgbot/api.go
+++ b/tgbot/api.go
@@ -146,6 +146,49 @@ func handleGetLogs(c fiber.Ctx) error {
 	return c.JSON(fiber.Map{"lines": lines})
 }
 
+func handleGetAIResults(c fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"results": recentAIResults(),
+		"labels":  aiCuratedLabels(),
+	})
+}
+
+func handleLabelAIResult(c fiber.Ctx) error {
+	var req struct {
+		Text string `json:"text"`
+		Kind string `json:"kind"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "请求格式错误"})
+	}
+	if err := labelAIEntry(req.Text, req.Kind); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(fiber.Map{"status": "ok"})
+}
+
+func handleGetAICurated(c fiber.Ctx) error {
+	kind := c.Params("kind")
+	if kind != "good" && kind != "bad" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "无效词条池"})
+	}
+	return c.JSON(fiber.Map{"entries": aiCuratedEntries(kind)})
+}
+
+func handleDeleteAICurated(c fiber.Ctx) error {
+	kind := c.Params("kind")
+	var req struct {
+		Text string `json:"text"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "请求格式错误"})
+	}
+	if !deleteAICuratedEntry(req.Text, kind) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "词条不存在或词条池无效"})
+	}
+	return c.JSON(fiber.Map{"status": "ok"})
+}
+
 // BrowserOnlyMiddleware Sec-Fetch-Site 浏览器校验（Forbidden Header，JS 无法伪造）
 func BrowserOnlyMiddleware(c fiber.Ctx) error {
 	secFetchSite := c.Get("Sec-Fetch-Site")
@@ -205,6 +248,10 @@ func SetupRoutes(app *fiber.App) {
 	app.Get("/api/admin/tokens", AuthMiddleware, handleListTokens)
 	app.Post("/api/admin/tokens", AuthMiddleware, handleCreateToken)
 	app.Delete("/api/admin/tokens/:id", AuthMiddleware, handleDeleteToken)
+	app.Get("/api/admin/ai/results", AuthMiddleware, handleGetAIResults)
+	app.Put("/api/admin/ai/results/label", AuthMiddleware, handleLabelAIResult)
+	app.Get("/api/admin/ai/curated/:kind", AuthMiddleware, handleGetAICurated)
+	app.Delete("/api/admin/ai/curated/:kind", AuthMiddleware, handleDeleteAICurated)
 
 	// 用户统计 API（需要 API Token 认证）
 	app.Get("/api/user/:id/stats", APITokenMiddleware, handleUserStats)

--- a/tgbot/artificialIdiot.go
+++ b/tgbot/artificialIdiot.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
-
-	"math/rand/v2"
 
 	openai "github.com/sashabaranov/go-openai"
 )
@@ -28,8 +28,20 @@ var AISamples []string = []string{
 	"胡萝卜玉米猪骨汤",
 }
 
-var promptDefault = "你是一个算命机器人，会随机给出一些老黄历词条，类似：[宜xxxxxxx][忌xxxxxxx]，词条范围包含但不限于与[今天的日期]、[现在的时间]相关的活动、[Ingress]游戏中的行为、衣服穿搭、发型发色、交通工具、饮食搭配、经典网络迷因、流行搞笑梗等等各种有趣的东西；其中，Ingress中的[名词]均使用英文。词条必须简短不含逗号，但是需要搞笑有趣、幽默讽刺。当今天是节日时，生成词条尽量与节日相关，生成词条不含“宜”或“忌”的前缀，但是需要保证词条加上“宜”或“忌”的前缀时都意思通顺，生成的词条均以大括号{}括住，请参考后面的生成词条示例，再生成13条词条。\n"
-var promptEnd = "请仅回答生成的词条，每个词条一行。"
+var defaultGoodSamples = []string{
+	"拒接领导电话", "翘班去钓鱼", "边砍圣诞树边刷AP", "投食减肥者", "变得不幸",
+	"橙色针织裙", "搭星舰去上班", "带猫猫参加IFS", "胡萝卜玉米猪骨汤", "给Portal贴膜",
+	"把XMP当烟花", "用ADA处理前任", "在Link上走钢丝", "给Scanner充电到忘记睡觉",
+	"把低电量当人生哲学", "穿拖鞋参加战术会议", "骑共享单车追稀有Portal",
+	"在咖啡里找XM", "把通勤路线画成Field", "和敌对阵营拼桌", "给背包做减法",
+	"在雨里更新Scanner", "把钥匙串当护身符", "给B8许愿", "假装看不见群消息",
+	"把午休献给Portal", "在地铁里规划大三角", "为一根Link熬夜", "把IFS当相亲局",
+	"用Jarvis解决选择困难", "被风吹乱战术发型", "给外卖备注阵营色", "在奶茶里加抵抗",
+	"把加班解释为刷AP", "对着地图假装很忙", "把雨伞当Portal天线", "给鞋带打战术结",
+	"把迷路称为实地勘测", "在凌晨维护社交能量", "给闹钟设置成Scanner提示音",
+}
+
+var promptDefault = "你是 Ingress 主题的老黄历词条生成器。词条范围包含与日期和小时相关的活动、Ingress 游戏行为、穿搭、交通、饮食、网络迷因和流行梗；Ingress 专有名词必须使用英文。词条应简短、搞笑且有讽刺感，不含“宜”或“忌”前缀、逗号或大括号，且不超过 64 个 Unicode 字符。每条必须同时能自然接在“宜”和“忌”之后。不要重复示例或同一批中的其他词条。\n"
 
 func GetChineseWeekday(t time.Time) string {
 	// 数组下标 0-6 分别对应周日到周六
@@ -47,20 +59,12 @@ type AIInstance struct {
 	Valid  bool
 }
 
-var AIContentPool []string
-var AINextHourPool []string
 var AIs []*AIInstance
 
-func AIContentPush(pool *[]string, s string) {
-	*pool = append(*pool, s)
-	for len(*pool) > 20 {
-		*pool = (*pool)[1:]
-	}
-}
-
 var aiContext, cancelAI = context.WithCancel(context.Background())
+var aiGenerationMu sync.Mutex
 
-// 每个模型独立退避；轮换下标跨次调用延续
+// 每个模型独立退避；配置顺序同时是调用优先级。
 type openaiModelState struct {
 	nextRetry    time.Time
 	failureDelay time.Duration
@@ -69,7 +73,6 @@ type openaiModelState struct {
 var (
 	openaiModelMu     sync.Mutex
 	openaiModelStates = map[string]*openaiModelState{}
-	openaiNextIdx     int
 )
 
 const (
@@ -81,7 +84,6 @@ func resetOpenAIModelStates() {
 	openaiModelMu.Lock()
 	defer openaiModelMu.Unlock()
 	openaiModelStates = make(map[string]*openaiModelState)
-	openaiNextIdx = 0
 }
 
 func modelStateLocked(name string) *openaiModelState {
@@ -108,68 +110,16 @@ func initAIs() {
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 
-		lastHour := time.Now().Hour()
-
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
 				now := time.Now()
-				currentHour := now.Hour()
-				currentMinute := now.Minute()
-
-				// 1. 整点切换逻辑
-				if currentHour != lastHour {
-					fmt.Printf("New hour detected: %d (was %d). Switching AIContentPool.\n", currentHour, lastHour)
-					if len(AINextHourPool) > 0 {
-						AIContentPool = AINextHourPool
-						AINextHourPool = make([]string, 0)
-					} else {
-						// 如果预取失败了，整点至少清空旧的（过期的）
-						AIContentPool = make([]string, 0)
-					}
-					lastHour = currentHour
-				}
-
-				// 2. 触发决策逻辑
-				var targetPool *[]string
-				var targetTime time.Time
-				isPrefetch := false
-
-				if currentMinute == 59 {
-					// 59分进入预取模式
-					if len(AINextHourPool) < 5 {
-						targetPool = &AINextHourPool
-						targetTime = now.Add(time.Hour)
-						isPrefetch = true
-					}
-				} else {
-					// 常规模式：池不满 且 预取池为空；退避由各模型自行计算
-					if len(AIContentPool) < 5 && len(AINextHourPool) == 0 {
-						targetPool = &AIContentPool
-						targetTime = now
-					}
-				}
-
-				// 3. 执行更新
-				if targetPool != nil {
-					var success bool
-					for _, ai := range shuffle(AIs) {
-						if ai.Valid {
-							if err := ai.Update(ai, targetTime, targetPool); err == nil {
-								success = true
-								break
-							}
-						}
-					}
-
-					if success {
-						fmt.Printf("AI content updated successfully (Prefetch: %v) at %s\n", isPrefetch, now.Format("15:04:05"))
-					} else if isPrefetch {
-						fmt.Printf("Prefetch AI update failed at %s, will retry soon\n", now.Format("15:04:05"))
-					} else {
-						fmt.Printf("Regular AI update failed at %s (per-model backoff)\n", now.Format("15:04:05"))
+				pruneAIHourlyContent(now)
+				if aiContentNeedsRefill(now) {
+					if err := refreshAIContent(now); err != nil {
+						fmt.Printf("AI content refill failed at %s: %v\n", now.Format("15:04:05"), err)
 					}
 				}
 			}
@@ -177,11 +127,23 @@ func initAIs() {
 	}(aiContext)
 }
 
-func shuffle(arr []*AIInstance) []*AIInstance {
-	rand.Shuffle(len(arr), func(i, j int) {
-		arr[i], arr[j] = arr[j], arr[i]
-	})
-	return arr
+func refreshAIContent(t time.Time) error {
+	aiGenerationMu.Lock()
+	defer aiGenerationMu.Unlock()
+	if !aiContentNeedsRefill(t) {
+		return nil
+	}
+	for _, ai := range AIs {
+		if ai.Valid {
+			if err := ai.Update(ai, t, nil); err == nil {
+				fmt.Printf("AI content batch appended at %s\n", t.Format("15:04:05"))
+				return nil
+			} else {
+				return err
+			}
+		}
+	}
+	return errors.New("no valid AI provider")
 }
 
 func initOpenAI(self *AIInstance) {
@@ -197,7 +159,7 @@ func initOpenAI(self *AIInstance) {
 	}
 	openaiClient = openai.NewClientWithConfig(config)
 	resetOpenAIModelStates()
-	if getContentOpenAI(self, time.Now(), &AIContentPool) == nil {
+	if getContentOpenAI(self, time.Now(), nil) == nil {
 		self.Valid = true
 	} else {
 		self.Valid = false
@@ -221,14 +183,27 @@ func reloadAIConfig() {
 }
 
 func AIContentValid() bool {
-	return len(AIContentPool) > 0
+	aiContentMu.Lock()
+	defer aiContentMu.Unlock()
+	return len(aiHourlyContent[hourKey(time.Now())]) > 0
 }
 
 func AIContentPop() (result string) {
-	resultIdx := rand.IntN(len(AIContentPool))
-	result = AIContentPool[resultIdx]
-	AIContentPool = append(AIContentPool[:resultIdx], AIContentPool[resultIdx+1:]...)
-	fmt.Println("len:", len(AIContentPool), "result:", result)
+	aiContentMu.Lock()
+	defer aiContentMu.Unlock()
+	hour := hourKey(time.Now())
+	pool := aiHourlyContent[hour]
+	if len(pool) == 0 {
+		return ""
+	}
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(pool))))
+	if err != nil {
+		return ""
+	}
+	resultIdx := int(idx.Int64())
+	result = pool[resultIdx]
+	aiHourlyContent[hour] = append(pool[:resultIdx], pool[resultIdx+1:]...)
+	fmt.Println("AI current-hour pool len:", len(aiHourlyContent[hour]), "result:", result)
 	return result
 }
 
@@ -254,27 +229,28 @@ func getContentOpenAI(self *AIInstance, t time.Time, pool *[]string) (err error)
 		Content: getPrompt(t),
 	}}
 	return rotateTryModels(models, func(model string) error {
-		return callOpenAIModel(model, prompt, self, pool)
+		entries, err := callOpenAIModel(model, prompt)
+		if err != nil {
+			return err
+		}
+		appendAIHourlyContent(entries)
+		recordAIResults(entries)
+		return nil
 	})
 }
 
-// rotateTryModels 从 openaiNextIdx 起轮换；跳过退避中的模型；失败立即试下一个并单独退避
+// rotateTryModels 始终从配置的首个模型开始；仅首选不可用时顺序 fallback。
 func rotateTryModels(models []string, call func(string) error) error {
 	if len(models) == 0 {
 		return errors.New("no models")
 	}
-
-	openaiModelMu.Lock()
-	start := openaiNextIdx % len(models)
-	openaiModelMu.Unlock()
 
 	var lastErr error
 	tried := 0
 	now := time.Now()
 
 	for i := 0; i < len(models); i++ {
-		idx := (start + i) % len(models)
-		model := models[idx]
+		model := models[i]
 
 		openaiModelMu.Lock()
 		st := modelStateLocked(model)
@@ -293,7 +269,6 @@ func rotateTryModels(models []string, call func(string) error) error {
 			st = modelStateLocked(model)
 			st.failureDelay = openaiInitialBackoff
 			st.nextRetry = time.Time{}
-			openaiNextIdx = (idx + 1) % len(models)
 			openaiModelMu.Unlock()
 			return nil
 		}
@@ -319,7 +294,7 @@ func rotateTryModels(models []string, call func(string) error) error {
 	return errors.New("all models failed")
 }
 
-func callOpenAIModel(model string, prompt []openai.ChatCompletionMessage, self *AIInstance, pool *[]string) error {
+func callOpenAIModel(model string, prompt []openai.ChatCompletionMessage) ([]AIRecentResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	req := openai.ChatCompletionRequest{
@@ -352,28 +327,85 @@ func callOpenAIModel(model string, prompt []openai.ChatCompletionMessage, self *
 		} else {
 			fmt.Printf("Generic Error: %v\n", err)
 		}
-		return err
+		return nil, err
 	}
 
-	lines := strings.Split(resp.Choices[0].Message.Content, "\n")
-	re := regexp.MustCompile(`\{(.+?)\}`)
-	for _, v := range lines {
-		match := re.FindStringSubmatch(v)
-		if len(match) > 0 {
-			AIContentPush(pool, match[1])
-			fmt.Println(self.Name, "AI result add:", match[1], "to pool size:", len(*pool))
-		}
+	if len(resp.Choices) == 0 {
+		return nil, errors.New("AI returned no choices")
 	}
-	return nil
+	entries, err := parseAIHourlyResults(resp.Choices[0].Message.Content, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 func getPrompt(t time.Time) string {
-	sample := ""
-	for _, v := range AISamples {
-		sample += "{" + v + "} "
+	start := t.Truncate(time.Hour)
+	good := randomAIEntries(aiCuratedEntries("good"), 40)
+	for _, sample := range defaultGoodSamples {
+		if len(good) >= 40 {
+			break
+		}
+		good = append(good, sample)
 	}
-	fmt.Println("generate AI result with:\n", sample)
+	bad := randomAIEntries(aiCuratedEntries("bad"), 10)
+	defaultBad := []string{"吃饭", "睡觉", "开心", "努力工作", "一切顺利", "喝水", "刷手机", "出门", "休息", "加油"}
+	for _, sample := range defaultBad {
+		if len(bad) >= 10 {
+			break
+		}
+		bad = append(bad, sample)
+	}
 
-	p := promptDefault + sample + "\n现在是" + todayChineseDateTime(t) + "，" + promptEnd
-	return p
+	hours := make([]string, 0, aiBatchHours)
+	for i := 0; i < aiBatchHours; i++ {
+		hours = append(hours, hourKey(start.Add(time.Duration(i)*time.Hour)))
+	}
+	return fmt.Sprintf("%s\n当前时间是%s。请为以下每个小时各生成恰好 %d 条词条：%s。\n"+
+		"优质风格参考（可学习风格但禁止复用）：%s。\n"+
+		"负面示例（禁止模仿其平淡、泛化或无趣的风格）：%s。\n"+
+		"只输出 %d 行，严格格式为 [YYYY-MM-DD HH]{词条}；每个所列小时必须有 %d 行。",
+		promptDefault, todayChineseDateTime(t), aiEntriesPerHour, strings.Join(hours, "、"),
+		wrapAISamples(good), wrapAISamples(bad), aiBatchHours*aiEntriesPerHour, aiEntriesPerHour)
+}
+
+func wrapAISamples(samples []string) string {
+	out := make([]string, 0, len(samples))
+	for _, sample := range samples {
+		out = append(out, "{"+sample+"}")
+	}
+	return strings.Join(out, " ")
+}
+
+var aiHourlyResultPattern = regexp.MustCompile(`(?m)^\s*\[(\d{4}-\d{2}-\d{2} \d{2})\]\{([^{}\r\n]+)\}\s*$`)
+
+func parseAIHourlyResults(content string, t time.Time) ([]AIRecentResult, error) {
+	expected := make(map[string]bool, aiBatchHours)
+	start := t.Truncate(time.Hour)
+	for i := 0; i < aiBatchHours; i++ {
+		expected[hourKey(start.Add(time.Duration(i)*time.Hour))] = true
+	}
+	perHour := make(map[string][]AIRecentResult, aiBatchHours)
+	seen := make(map[string]bool)
+	for _, match := range aiHourlyResultPattern.FindAllStringSubmatch(content, -1) {
+		hour, text := match[1], strings.TrimSpace(match[2])
+		if !expected[hour] || text == "" || len([]rune(text)) > 64 || seen[hour+"\x00"+text] {
+			continue
+		}
+		seen[hour+"\x00"+text] = true
+		if len(perHour[hour]) < aiEntriesPerHour {
+			perHour[hour] = append(perHour[hour], AIRecentResult{
+				Text: text, Hour: hour, GeneratedAt: time.Now().Format(gTimeFormat),
+			})
+		}
+	}
+	entries := make([]AIRecentResult, 0, aiBatchHours*aiEntriesPerHour)
+	for hour := range expected {
+		if len(perHour[hour]) < aiEntriesPerHour {
+			return nil, fmt.Errorf("AI returned only %d valid entries for %s", len(perHour[hour]), hour)
+		}
+		entries = append(entries, perHour[hour]...)
+	}
+	return entries, nil
 }

--- a/tgbot/main.go
+++ b/tgbot/main.go
@@ -68,6 +68,7 @@ func SetupApp() {
 	// 加载 API Token 和用户统计缓存
 	loadAPITokens()
 	loadUserStats()
+	loadAIContentStore()
 
 	// 从配置中读取运行时变量
 	gToken = GetBotToken()

--- a/tgbot/openai_models_test.go
+++ b/tgbot/openai_models_test.go
@@ -31,15 +31,14 @@ func TestParseOpenAIModels(t *testing.T) {
 	}
 }
 
-// ponytail: 不打真实 API；验证跳过退避模型、失败立即换下一个
-func TestOpenAIModelRotationBackoff(t *testing.T) {
+// ponytail: 不打真实 API；验证首选退避时才 fallback，失败立即换下一个。
+func TestOpenAIModelPriorityBackoff(t *testing.T) {
 	resetOpenAIModelStates()
 	models := []string{"m1", "m2", "m3"}
 
 	openaiModelMu.Lock()
 	st1 := modelStateLocked("m1")
 	st1.nextRetry = time.Now().Add(time.Hour)
-	openaiNextIdx = 0
 	openaiModelMu.Unlock()
 
 	order := make([]string, 0)
@@ -59,13 +58,25 @@ func TestOpenAIModelRotationBackoff(t *testing.T) {
 
 	openaiModelMu.Lock()
 	defer openaiModelMu.Unlock()
-	if openaiNextIdx != 0 { // (m3 idx 2 + 1) % 3 == 0
-		t.Fatalf("openaiNextIdx=%d want 0", openaiNextIdx)
-	}
 	if !modelStateLocked("m2").nextRetry.After(time.Now()) {
 		t.Fatal("m2 should be in backoff after failure")
 	}
 	if !modelStateLocked("m3").nextRetry.IsZero() {
 		t.Fatal("m3 backoff should be cleared on success")
+	}
+}
+
+func TestOpenAIModelPriorityUsesFirstHealthyModel(t *testing.T) {
+	resetOpenAIModelStates()
+	order := make([]string, 0)
+	err := rotateTryModels([]string{"m1", "m2"}, func(model string) error {
+		order = append(order, model)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(order) != 1 || order[0] != "m1" {
+		t.Fatalf("order=%v want [m1]", order)
 	}
 }

--- a/website/src/routes/admin/+layout.svelte
+++ b/website/src/routes/admin/+layout.svelte
@@ -18,6 +18,12 @@
 			<li>
 				<a href="/admin/tokens" class:active={currentPath === '/admin/tokens'}> 🔑 API Token </a>
 			</li>
+			<li>
+				<a href="/admin/ai-results" class:active={currentPath === '/admin/ai-results'}> ✨ AI 结果 </a>
+			</li>
+			<li>
+				<a href="/admin/ai-library" class:active={currentPath === '/admin/ai-library'}> 📚 AI 词条库 </a>
+			</li>
 		</ul>
 		<div class="divider"></div>
 		<a href="/" class="btn btn-ghost btn-sm">← 返回首页</a>

--- a/website/src/routes/admin/+page.svelte
+++ b/website/src/routes/admin/+page.svelte
@@ -208,12 +208,12 @@
 						<textarea
 							id="openai_model"
 							bind:value={formData.openai_model}
-							placeholder={'每行一个模型，失败自动切换下一个\n例如:\ngpt-4o-mini\ngpt-4o'}
+							placeholder={'每行一个模型，按顺序优先调用，失败才切换\n例如:\ngpt-4o-mini\ngpt-4o'}
 							class="textarea textarea-bordered font-mono text-sm"
 							rows="4"
 						></textarea>
 						<label class="label" for="openai_model">
-							<span class="label-text-alt">留空不修改；多个模型会轮换调用，各自独立退避重试</span>
+							<span class="label-text-alt">留空不修改；首个模型优先，失败时按顺序 fallback，各自独立退避重试</span>
 						</label>
 					</div>
 				</div>

--- a/website/src/routes/admin/ai-library/+page.svelte
+++ b/website/src/routes/admin/ai-library/+page.svelte
@@ -1,0 +1,112 @@
+<script>
+	import { onMount } from 'svelte';
+
+	let good = [];
+	let bad = [];
+	let loading = true;
+	let error = '';
+	let success = '';
+
+	onMount(loadEntries);
+
+	async function loadEntries() {
+		const token = localStorage.getItem('auth_token');
+		loading = true;
+		try {
+			const headers = { Authorization: `Bearer ${token}` };
+			const [goodRes, badRes] = await Promise.all([
+				fetch('/api/admin/ai/curated/good', { headers }),
+				fetch('/api/admin/ai/curated/bad', { headers })
+			]);
+			if (!goodRes.ok || !badRes.ok) throw new Error();
+			good = (await goodRes.json()).entries || [];
+			bad = (await badRes.json()).entries || [];
+		} catch (e) {
+			error = '加载长期词条库失败';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function deleteEntry(text, kind) {
+		if (!confirm(`确认从 ${kind} 池删除“${text}”？`)) return;
+		const token = localStorage.getItem('auth_token');
+		error = '';
+		success = '';
+		try {
+			const res = await fetch(`/api/admin/ai/curated/${kind}`, {
+				method: 'DELETE',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${token}`
+				},
+				body: JSON.stringify({ text })
+			});
+			if (!res.ok) throw new Error();
+			if (kind === 'good') good = good.filter((entry) => entry !== text);
+			else bad = bad.filter((entry) => entry !== text);
+			success = '词条已删除';
+		} catch (e) {
+			error = '删除词条失败';
+		}
+	}
+</script>
+
+<div class="max-w-4xl">
+	<h1 class="text-2xl font-bold mb-2">AI 长期词条库</h1>
+	<p class="text-sm text-base-content/60 mb-6">good 用作优质风格参考；bad 用作负面示例，提示模型避免类似内容。</p>
+
+	{#if error}
+		<div class="alert alert-error mb-4"><span>{error}</span></div>
+	{/if}
+	{#if success}
+		<div class="alert alert-success mb-4"><span>{success}</span></div>
+	{/if}
+
+	{#if loading}
+		<div class="flex justify-center py-8"><span class="loading loading-spinner loading-lg"></span></div>
+	{:else}
+		<div class="grid gap-6 lg:grid-cols-2">
+			<section class="card bg-base-200">
+				<div class="card-body">
+					<h2 class="card-title">good <span class="badge badge-success">{good.length}</span></h2>
+					{#if good.length === 0}
+						<p class="text-base-content/50">暂无词条</p>
+					{:else}
+						<ul class="flex flex-col gap-2">
+							{#each good as entry}
+								<li class="flex items-center justify-between gap-3">
+									<span class="break-all">{entry}</span>
+									<button
+										class="btn btn-error btn-outline btn-xs shrink-0"
+										on:click={() => deleteEntry(entry, 'good')}>删除</button
+									>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			</section>
+			<section class="card bg-base-200">
+				<div class="card-body">
+					<h2 class="card-title">bad <span class="badge badge-error">{bad.length}</span></h2>
+					{#if bad.length === 0}
+						<p class="text-base-content/50">暂无词条</p>
+					{:else}
+						<ul class="flex flex-col gap-2">
+							{#each bad as entry}
+								<li class="flex items-center justify-between gap-3">
+									<span class="break-all">{entry}</span>
+									<button
+										class="btn btn-error btn-outline btn-xs shrink-0"
+										on:click={() => deleteEntry(entry, 'bad')}>删除</button
+									>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			</section>
+		</div>
+	{/if}
+</div>

--- a/website/src/routes/admin/ai-results/+page.svelte
+++ b/website/src/routes/admin/ai-results/+page.svelte
@@ -1,0 +1,110 @@
+<script>
+	import { onMount } from 'svelte';
+
+	let results = [];
+	let labels = {};
+	let loading = true;
+	let error = '';
+	let success = '';
+
+	onMount(loadResults);
+
+	async function loadResults() {
+		const token = localStorage.getItem('auth_token');
+		loading = true;
+		try {
+			const res = await fetch('/api/admin/ai/results', {
+				headers: { Authorization: `Bearer ${token}` }
+			});
+			if (!res.ok) throw new Error();
+			const data = await res.json();
+			results = data.results || [];
+			labels = data.labels || {};
+		} catch (e) {
+			error = '加载 AI 结果失败';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function labelResult(text, kind) {
+		const token = localStorage.getItem('auth_token');
+		error = '';
+		success = '';
+		try {
+			const res = await fetch('/api/admin/ai/results/label', {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${token}`
+				},
+				body: JSON.stringify({ text, kind })
+			});
+			if (!res.ok) throw new Error();
+			labels = { ...labels, [text]: kind };
+			success = `已标记为 ${kind}`;
+		} catch (e) {
+			error = '标记词条失败';
+		}
+	}
+</script>
+
+<div class="max-w-4xl">
+	<h1 class="text-2xl font-bold mb-2">AI 最近结果</h1>
+	<p class="text-sm text-base-content/60 mb-6">显示最近 100 条已接受的 AI 词条。标记会保存到长期词条库。</p>
+
+	{#if error}
+		<div class="alert alert-error mb-4"><span>{error}</span></div>
+	{/if}
+	{#if success}
+		<div class="alert alert-success mb-4"><span>{success}</span></div>
+	{/if}
+
+	{#if loading}
+		<div class="flex justify-center py-8"><span class="loading loading-spinner loading-lg"></span></div>
+	{:else if results.length === 0}
+		<div class="text-center py-8 text-base-content/50">暂无 AI 生成结果</div>
+	{:else}
+		<div class="overflow-x-auto">
+			<table class="table table-zebra">
+				<thead>
+					<tr>
+						<th>词条</th>
+						<th>适用小时</th>
+						<th>生成时间</th>
+						<th>标签</th>
+						<th>操作</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each results as result}
+						<tr>
+							<td class="font-medium">{result.text}</td>
+							<td class="text-sm whitespace-nowrap">{result.hour}</td>
+							<td class="text-sm whitespace-nowrap">{result.generated_at}</td>
+							<td>
+								{#if labels[result.text] === 'good'}
+									<span class="badge badge-success">good</span>
+								{:else if labels[result.text] === 'bad'}
+									<span class="badge badge-error">bad</span>
+								{:else}
+									<span class="text-base-content/50">未标记</span>
+								{/if}
+							</td>
+							<td class="flex gap-2">
+								<button
+									class="btn btn-success btn-outline btn-xs"
+									on:click={() => labelResult(result.text, 'good')}>good</button
+								>
+								<button
+									class="btn btn-error btn-outline btn-xs"
+									on:click={() => labelResult(result.text, 'bad')}>bad</button
+								>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>

--- a/website/src/routes/templates/+page.svelte
+++ b/website/src/routes/templates/+page.svelte
@@ -50,7 +50,6 @@
 	];
 	const exampleIdx = Math.floor(Math.random() * exampleSentences.length);
 	let sentence = exampleSentences[exampleIdx];
-	let sentenceDepth = 1;
 	let templateResult = '-';
 	let templateSlice = [];
 	let errTitle = '';
@@ -92,7 +91,7 @@
 		error = false;
 		let templateReplaced = 0;
 		const templateReplace = (_, name) => {
-			if (!templates.hasOwnProperty(name)) {
+			if (!Object.prototype.hasOwnProperty.call(templates, name)) {
 				error = true;
 				showError('错误', '不存在 {{' + name + '}} 模板');
 				return '{{' + name + '}}';
@@ -106,7 +105,7 @@
 		};
 		templateSlice = [];
 		templateResult = str.replaceAll(templatesRegexp, templateReplace);
-		[...templateResult.matchAll(/\[?([^\[\]]+)\]?/g)].forEach((match) => {
+		[...templateResult.matchAll(/\[?([^[\]]+)\]?/g)].forEach((match) => {
 			// console.log(match)
 			templateSlice.push({
 				isTemplate: match[1].length !== match[0].length ? true : false,
@@ -119,7 +118,6 @@
 			showError('错误', '词条使用了超过 4 个模板');
 		}
 		if (!error) {
-			sentenceDepth = getDepthOfEntry(str);
 			roller.start();
 		} else {
 			roller.stop();


### PR DESCRIPTION
## Summary
- generate and validate 60 hour-scoped AI entries per request, using configured model priority with fallback
- persist recent generated results and curated good/bad examples to improve subsequent prompts
- add authenticated admin screens and APIs for reviewing and managing AI examples

## Test plan
- [x] `go test ./...`
- [x] `npm run lint`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)